### PR TITLE
feat(shopping): implement shopping info endpoints

### DIFF
--- a/.claude/plans/recommendations-shopping.md
+++ b/.claude/plans/recommendations-shopping.md
@@ -1,0 +1,533 @@
+# Plan: Recommendations & Shopping Feature Data Sources
+
+## Data Source Strategy Summary
+
+| Feature              | Data Source         | Rationale                                                |
+| -------------------- | ------------------- | -------------------------------------------------------- |
+| **Substitutions**    | LLM (Groq)          | Follows existing pattern, flexible, handles edge cases   |
+| **Pairings**         | LLM (Groq)          | Follows existing pattern, generates creative suggestions |
+| **Shopping/Pricing** | USDA-based database | User preference for reliability over LLM estimation      |
+
+---
+
+## Part 1: Recommendations Feature (LLM-Powered)
+
+### Architecture Overview
+
+Both substitutions and pairings will follow the existing LLM pattern established by `RecipeLinkExtractor`:
+
+```
+API Request → Service → LLM Client (Groq) → Structured Response
+                ↓
+            Redis Cache (configurable TTL)
+```
+
+### 1.1 Ingredient Substitutions
+
+**Data Flow:**
+
+1. Receive ingredient ID + optional quantity
+2. Fetch ingredient details from Recipe Management Service
+3. Generate LLM prompt with ingredient context
+4. Parse structured JSON response with substitutes + conversion ratios
+5. Cache result by ingredient name
+
+**LLM Prompt Strategy:**
+
+```
+Given ingredient: {name} ({food_group})
+Optional context: quantity {amount} {unit}
+
+Generate 5-10 substitutions with:
+- Substitute ingredient name
+- Conversion ratio (e.g., 0.75x for whole wheat flour replacing all-purpose)
+- Best use case (baking, cooking, raw)
+- Flavor/texture notes
+```
+
+**Response Schema (Pydantic):**
+
+```python
+class SubstitutionResult(BaseModel):
+    ingredient: str
+    conversion_ratio: float
+    conversion_unit: IngredientUnit
+    notes: str | None
+    confidence: float  # 0-1 from LLM
+```
+
+**Cache Strategy:**
+
+- Key: `substitution:{ingredient_name_normalized}`
+- TTL: 7 days (substitutions are relatively stable)
+- Store raw LLM output, paginate at response time
+
+### 1.2 Recipe Pairings
+
+**Data Flow:**
+
+1. Receive recipe ID
+2. Fetch recipe details (title, ingredients, cuisine tags)
+3. Generate LLM prompt with recipe context
+4. Parse structured JSON response with pairing suggestions
+5. Cache result by recipe ID
+
+**LLM Prompt Strategy:**
+
+```
+Recipe: {title}
+Key ingredients: {top_5_ingredients}
+Cuisine type: {cuisine} (if available)
+Meal type: {meal_type} (if available)
+
+Suggest 5-10 complementary recipes/dishes that:
+- Balance the meal nutritionally
+- Complement flavor profiles
+- Match cuisine style
+- Consider course (appetizer, side, dessert)
+```
+
+**Response Schema:**
+
+```python
+class PairingSuggestion(BaseModel):
+    recipe_name: str
+    url: str | None  # If known recipe URL
+    pairing_reason: str
+    course_type: str  # appetizer, side, main, dessert
+    confidence: float
+```
+
+**Cache Strategy:**
+
+- Key: `pairing:{recipe_id}`
+- TTL: 24 hours (shorter since recipes may change)
+
+---
+
+## Part 2: Shopping Feature (Database-Powered)
+
+### Architecture Overview
+
+```
+API Request → Service → Pricing Repository → PostgreSQL
+                ↓              ↓
+            Redis Cache    ingredient_pricing → food_group_pricing (fallback)
+```
+
+### 2.1 Database Schema Design
+
+**Two-tier approach: Per-ingredient + food group fallback**
+
+✅ **IMPLEMENTED** in `schema-copy/052_create_ingredient_pricing_table.sql` and `schema-copy/053_create_food_group_pricing_table.sql`
+
+```sql
+-- Primary: Per-ingredient pricing (USDA + Kaggle import)
+CREATE TABLE recipe_manager.ingredient_pricing (
+    pricing_id BIGSERIAL PRIMARY KEY,
+    ingredient_id BIGINT NOT NULL UNIQUE REFERENCES ingredients(ingredient_id) ON DELETE CASCADE,
+    price_per_100g DECIMAL(10,4) NOT NULL CHECK (price_per_100g >= 0),
+    currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+    data_source VARCHAR(50) NOT NULL CHECK (data_source IN ('USDA_FVP', 'USDA_MEAT', 'USDA_FMAP', 'KAGGLE', 'MANUAL')),
+    source_year INTEGER CHECK (source_year IS NULL OR (source_year >= 2000 AND source_year <= 2100)),
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Fallback: Food group averages (uses FOOD_GROUP_ENUM for type safety)
+CREATE TABLE recipe_manager.food_group_pricing (
+    food_group FOOD_GROUP_ENUM PRIMARY KEY,  -- VEGETABLES, FRUITS, GRAINS, etc.
+    avg_price_per_100g DECIMAL(10,4) NOT NULL CHECK (avg_price_per_100g >= 0),
+    currency VARCHAR(3) NOT NULL DEFAULT 'USD',
+    data_source VARCHAR(50) NOT NULL DEFAULT 'USDA_FMAP' CHECK (data_source IN ('USDA_FVP', 'USDA_MEAT', 'USDA_FMAP', 'KAGGLE', 'MANUAL')),
+    notes TEXT,
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+### 2.2 Pricing Data Sources
+
+**Primary Sources (Per-Ingredient):**
+
+| Source    | Dataset                                                                                       | Items     | Coverage                                 |
+| --------- | --------------------------------------------------------------------------------------------- | --------- | ---------------------------------------- |
+| USDA_FVP  | [Fruit & Vegetable Prices](https://www.ers.usda.gov/data-products/fruit-and-vegetable-prices) | 150+      | Produce                                  |
+| USDA_MEAT | [Meat Price Spreads](https://www.ers.usda.gov/data-products/meat-price-spreads)               | ~50       | Beef, pork, chicken, turkey, eggs, dairy |
+| KAGGLE    | TBD grocery dataset                                                                           | TBD       | Spices, grains, nuts, legumes, etc.      |
+| MANUAL    | Manual curation                                                                               | As needed | High-value or common items               |
+
+**Fallback Source (Food Group):**
+
+| Source    | Dataset                                                                                                | Groups |
+| --------- | ------------------------------------------------------------------------------------------------------ | ------ |
+| USDA_FMAP | [Food-at-Home Monthly Prices](https://www.ers.usda.gov/data-products/food-at-home-monthly-area-prices) | 90     |
+
+**Data Import Strategy:**
+
+1. Import USDA Fruit & Vegetable Prices (~150 items)
+2. Import USDA Meat Price Spreads (~50 items)
+3. Import Kaggle grocery data for gaps (spices, grains, nuts, legumes)
+4. Seed food group fallback from USDA F-MAP
+5. Manual curation for any remaining high-value items
+
+### 2.3 Price Calculation Flow
+
+**Ingredient Shopping Info:**
+
+1. Fetch ingredient by ID from Recipe Management Service
+2. **Tier 1:** Look up `price_per_100g` from `ingredient_pricing`
+3. **Tier 2 (fallback):** If not found, get `food_group` from `nutrition_profiles`, look up `avg_price_per_100g` from `food_group_pricing`
+4. Convert requested quantity to grams using `UnitConverter`
+5. Calculate: `price = (grams / 100) * price_per_100g`
+6. Return with source info and confidence level (higher for Tier 1)
+
+**Recipe Shopping Info:**
+
+1. Fetch all ingredients for recipe
+2. Calculate price for each ingredient (as above)
+3. Aggregate total
+4. Return breakdown + total + count of Tier 1 vs Tier 2 lookups
+
+### 2.4 Cache Strategy
+
+- Key: `shopping:{ingredient_id}:{amount}:{unit}`
+- TTL: 24 hours (prices can change)
+- Cache individual ingredient lookups
+- Don't cache recipe totals (computed from cached ingredients)
+
+---
+
+## Implementation Sequence
+
+### Phase 1: Core Infrastructure
+
+1. Add `food_group_pricing` table + seed data migration
+2. Create `PricingRepository` with food group lookup
+3. Create `PricingService` with caching layer
+4. Add pricing schemas to `/src/app/schemas/shopping.py`
+
+### Phase 2: Shopping Endpoints
+
+1. Implement `GET /ingredients/{id}/shopping-info`
+2. Implement `GET /recipes/{id}/shopping-info`
+3. Add integration tests
+
+### Phase 3: Recommendations Infrastructure
+
+1. Create `RecommendationsService` base class
+2. Add recommendation schemas to `/src/app/schemas/recommendations.py`
+3. Create LLM prompt templates
+
+### Phase 4: Recommendation Endpoints
+
+1. Implement `GET /ingredients/{id}/substitutions`
+2. Implement `GET /recipes/{id}/pairings`
+3. Add integration tests
+
+---
+
+## Files to Create/Modify
+
+### New Files
+
+```
+src/app/schemas/shopping.py           # Shopping response schemas
+src/app/schemas/recommendations.py    # Recommendation response schemas
+src/app/services/shopping/            # Shopping service directory
+  ├── __init__.py
+  ├── service.py                      # PricingService
+  └── repository.py                   # PricingRepository
+src/app/services/recommendations/     # Recommendations service directory
+  ├── __init__.py
+  ├── service.py                      # RecommendationsService
+  ├── substitutions.py                # Substitution logic
+  └── pairings.py                     # Pairing logic
+src/app/api/v1/endpoints/shopping.py  # Shopping endpoints (if separate file)
+```
+
+### Modified Files
+
+```
+src/app/api/v1/endpoints/ingredients.py  # Add substitutions, shopping-info
+src/app/api/v1/endpoints/recipes.py      # Add pairings, shopping-info
+src/app/api/v1/router.py                 # Register new routes
+src/app/database/repositories/__init__.py # Export PricingRepository
+```
+
+### Database Migration
+
+```
+migrations/versions/XXX_add_food_group_pricing.py
+```
+
+---
+
+## Testing & Documentation Requirements
+
+### Per-Task Testing Requirements
+
+#### Ingredient Substitutions Endpoint
+
+**Unit Tests:**
+
+- `test_substitutions_service_generates_valid_prompt` - LLM prompt includes ingredient name, food group
+- `test_substitutions_service_parses_llm_response` - Correctly extracts substitutions from JSON
+- `test_substitutions_service_caches_result` - Verifies Redis caching with correct key/TTL
+- `test_substitutions_schema_validation` - Response matches `SubstitutionResult` schema
+
+**Integration Tests:**
+
+- `test_substitutions_endpoint_returns_200` - Happy path with valid ingredient ID
+- `test_substitutions_endpoint_404_unknown_ingredient` - Returns 404 for non-existent ID
+- `test_substitutions_endpoint_pagination` - `limit` and `offset` work correctly
+- `test_substitutions_endpoint_with_quantity` - Optional `amount`/`measurement` params
+
+**Documentation:**
+
+- OpenAPI spec entry in `docs/api/recipe-scraper-openapi.yaml`
+- Example request/response in endpoint docstring
+
+---
+
+#### Recipe Pairings Endpoint
+
+**Unit Tests:**
+
+- `test_pairings_service_generates_valid_prompt` - LLM prompt includes recipe title, ingredients, cuisine
+- `test_pairings_service_parses_llm_response` - Correctly extracts pairings from JSON
+- `test_pairings_service_caches_result` - Verifies Redis caching with correct key/TTL
+- `test_pairings_schema_validation` - Response matches `PairingSuggestion` schema
+
+**Integration Tests:**
+
+- `test_pairings_endpoint_returns_200` - Happy path with valid recipe ID
+- `test_pairings_endpoint_404_unknown_recipe` - Returns 404 for non-existent ID
+- `test_pairings_endpoint_pagination` - `limit` and `offset` work correctly
+
+**Documentation:**
+
+- OpenAPI spec entry in `docs/api/recipe-scraper-openapi.yaml`
+- Example request/response in endpoint docstring
+
+---
+
+#### Ingredient Shopping Info Endpoint
+
+**Unit Tests:**
+
+- `test_pricing_repository_tier1_lookup` - Finds price in `ingredient_pricing`
+- `test_pricing_repository_tier2_fallback` - Falls back to `food_group_pricing`
+- `test_pricing_service_calculates_price` - `(grams / 100) * price_per_100g`
+- `test_pricing_service_caches_result` - Verifies Redis caching
+- `test_pricing_service_unit_conversion` - Correctly converts cups, tbsp, etc. to grams
+- `test_shopping_schema_validation` - Response matches schema
+
+**Integration Tests:**
+
+- `test_shopping_endpoint_returns_200` - Happy path with valid ingredient ID
+- `test_shopping_endpoint_404_unknown_ingredient` - Returns 404 for non-existent ID
+- `test_shopping_endpoint_with_quantity` - Scales price by `amount`/`measurement`
+- `test_shopping_endpoint_tier1_vs_tier2_confidence` - Higher confidence for Tier 1
+
+**Documentation:**
+
+- OpenAPI spec entry in `docs/api/recipe-scraper-openapi.yaml`
+- Example request/response in endpoint docstring
+
+---
+
+#### Recipe Shopping Info Endpoint
+
+**Unit Tests:**
+
+- `test_recipe_shopping_aggregates_ingredients` - Sums prices for all ingredients
+- `test_recipe_shopping_handles_missing_ingredients` - Graceful handling of unknowns
+- `test_recipe_shopping_response_structure` - Includes breakdown + total
+
+**Integration Tests:**
+
+- `test_recipe_shopping_endpoint_returns_200` - Happy path with valid recipe ID
+- `test_recipe_shopping_endpoint_404_unknown_recipe` - Returns 404 for non-existent ID
+- `test_recipe_shopping_endpoint_partial_pricing` - Returns 206 if some ingredients missing price
+
+**Documentation:**
+
+- OpenAPI spec entry in `docs/api/recipe-scraper-openapi.yaml`
+- Example request/response in endpoint docstring
+
+---
+
+### Manual Testing Checklist
+
+```bash
+# Shopping
+curl "http://localhost:8000/api/v1/recipe-scraper/ingredients/1/shopping-info?amount=2&measurement=CUP"
+curl "http://localhost:8000/api/v1/recipe-scraper/recipes/1/shopping-info"
+
+# Recommendations
+curl "http://localhost:8000/api/v1/recipe-scraper/ingredients/1/substitutions?limit=5"
+curl "http://localhost:8000/api/v1/recipe-scraper/recipes/1/pairings?limit=5"
+```
+
+### Definition of Done (Per Task)
+
+- [ ] All unit tests pass
+- [ ] All integration tests pass
+- [ ] OpenAPI spec updated
+- [ ] Endpoint docstring includes example
+- [ ] Manual curl test succeeds
+- [ ] Code reviewed
+
+---
+
+## Feature Documentation Requirements
+
+Following the format of `docs/nutritional-info.md` and `docs/allergen-info.md`, create two new documentation files:
+
+### `docs/recommendations.md` - Recommendations Feature
+
+**Table of Contents:**
+
+1. Overview (high-level architecture mermaid diagram)
+2. API Endpoints (substitutions + pairings with params/responses)
+3. Processing Flow (mermaid sequence diagrams for LLM flow)
+4. LLM Prompt Strategy (prompt templates, response parsing)
+5. Caching Strategy (mermaid diagram, keys, TTLs)
+6. Error Handling (LLM failures, fallbacks)
+
+**Required Mermaid Diagrams:**
+
+```mermaid
+graph TB
+    subgraph "Recommendations Architecture"
+        EP[Endpoint] --> SVC[RecommendationsService]
+        SVC --> CACHE[(Redis Cache)]
+        SVC --> LLM[Groq LLM Client]
+    end
+```
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant EP as Endpoint
+    participant RS as RecommendationsService
+    participant RC as Redis Cache
+    participant LLM as Groq LLM
+
+    C->>EP: GET /ingredients/{id}/substitutions
+    EP->>RS: get_substitutions(ingredient)
+    RS->>RC: Cache lookup
+    alt Cache Miss
+        RS->>LLM: Generate substitutions
+        LLM-->>RS: Structured JSON
+        RS->>RC: Cache result (7 days)
+    end
+    RS-->>EP: SubstitutionResponse
+    EP-->>C: 200 OK
+```
+
+---
+
+### `docs/shopping-info.md` - Shopping Feature
+
+**Table of Contents:**
+
+1. Overview (high-level architecture mermaid diagram)
+2. API Endpoints (ingredient + recipe shopping-info)
+3. Processing Flow (mermaid sequence diagrams)
+4. Two-Tier Pricing Lookup (mermaid flowchart)
+5. Price Calculation (formula, unit conversion)
+6. Caching Strategy (mermaid diagram, keys, TTLs)
+7. Database Schema (mermaid ER diagram)
+8. Error Handling (missing prices, fallbacks)
+9. Data Attribution (USDA ERS sources)
+
+**Required Mermaid Diagrams:**
+
+```mermaid
+graph TB
+    subgraph "Shopping Info Architecture"
+        EP[Endpoint] --> SVC[PricingService]
+        SVC --> CACHE[(Redis Cache)]
+        SVC --> REPO[PricingRepository]
+        REPO --> DB[(PostgreSQL)]
+    end
+
+    subgraph "Two-Tier Lookup"
+        REPO --> T1[Tier 1: ingredient_pricing]
+        REPO --> T2[Tier 2: food_group_pricing]
+    end
+```
+
+```mermaid
+flowchart TD
+    START[Price Lookup] --> T1{Tier 1:<br/>ingredient_pricing?}
+    T1 -->|Found| CALC[Calculate Price]
+    T1 -->|Not Found| T2{Tier 2:<br/>food_group_pricing?}
+    T2 -->|Found| CALC
+    T2 -->|Not Found| ERR[Return Error/Default]
+    CALC --> CONVERT[Convert Quantity to Grams]
+    CONVERT --> SCALE["price = (grams/100) × price_per_100g"]
+    SCALE --> RESP[Return Response]
+
+    style T1 fill:#90EE90
+    style T2 fill:#FFE4B5
+    style ERR fill:#FFB6C1
+```
+
+```mermaid
+erDiagram
+    ingredients ||--o| ingredient_pricing : has
+    ingredients ||--o| nutrition_profiles : has
+    nutrition_profiles }o--|| food_group_pricing : falls_back_to
+
+    ingredient_pricing {
+        bigint pricing_id PK
+        bigint ingredient_id FK
+        decimal price_per_100g
+        varchar currency
+        varchar data_source
+        int source_year
+    }
+
+    food_group_pricing {
+        varchar food_group PK
+        decimal avg_price_per_100g
+        varchar currency
+        varchar data_source
+    }
+```
+
+---
+
+## Decisions (Finalized)
+
+| Decision                | Choice                               | Rationale                                                                 |
+| ----------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| **Pricing granularity** | Per-ingredient + food group fallback | Two-tier: USDA/Kaggle data per ingredient, food group average as fallback |
+| **Data sources**        | USDA datasets + Kaggle supplement    | USDA FVP (produce), USDA Meat, Kaggle (spices/grains/nuts)                |
+| **Currency**            | USD only                             | MVP scope, can add multi-currency later                                   |
+| **Update frequency**    | Manual updates                       | Keep it simple, update seed data as needed                                |
+
+---
+
+## Beads Issue Structure
+
+✅ **EXISTING** - Issues already created in beads
+
+### Epic: Recommendations Feature (`recipe-scraper-service-7og`)
+
+- `recipe-scraper-service-6he` - Implement ingredient substitutions endpoint (LLM-powered)
+- `recipe-scraper-service-kjh` - Implement recipe pairings endpoint (LLM-powered)
+
+### Epic: Shopping Feature (`recipe-scraper-service-l8f`)
+
+- `recipe-scraper-service-a6b` - Implement ingredient shopping-info endpoint
+- `recipe-scraper-service-4hu` - Implement recipe shopping-info endpoint
+
+**Note:** Pricing data is seeded when the database is created (see `schema-copy/052_*` and `053_*`)
+
+### Dependencies
+
+- Recipe shopping-info depends on ingredient shopping-info (reuses PricingService)

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,3 +9,4 @@ ignores:
   - AGENTS.md
   - CLAUDE.md
   - .beads/**
+  - .claude/**

--- a/docs/shopping-info.md
+++ b/docs/shopping-info.md
@@ -1,0 +1,549 @@
+# Shopping Information Feature
+
+This document explains the shopping/pricing information lookup and aggregation system, which provides estimated grocery
+costs for ingredients and recipes using USDA pricing data.
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [API Endpoints](#2-api-endpoints)
+3. [Processing Flow](#3-processing-flow)
+4. [Two-Tier Pricing Strategy](#4-two-tier-pricing-strategy)
+5. [Unit Conversion](#5-unit-conversion)
+6. [Caching Strategy](#6-caching-strategy)
+7. [Database Schema](#7-database-schema)
+8. [Error Handling](#8-error-handling)
+9. [Data Attribution](#9-data-attribution)
+
+---
+
+## 1. Overview
+
+The shopping information feature provides estimated grocery costs for both individual ingredients and complete recipes.
+The system uses a two-tier pricing lookup strategy with USDA pricing data, falling back to food group averages when
+direct ingredient pricing is unavailable.
+
+### High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        C[Client Application]
+    end
+
+    subgraph "Recipe Scraper Service"
+        subgraph "API Layer"
+            INGR_EP["/ingredients/{id}/shopping-info"]
+            RECIPE_EP["/recipes/{id}/shopping-info"]
+        end
+
+        subgraph "Service Layer"
+            SS[ShoppingService]
+            UC[UnitConverter]
+        end
+
+        subgraph "Data Access"
+            PR[PricingRepository]
+        end
+    end
+
+    subgraph "Data Stores"
+        REDIS[(Redis Cache<br/>TTL: 24 hours)]
+        PG[(PostgreSQL<br/>Pricing Data)]
+    end
+
+    subgraph "External"
+        RMS[Recipe Management<br/>Service]
+    end
+
+    C -->|GET| INGR_EP
+    C -->|GET| RECIPE_EP
+    RECIPE_EP -->|Fetch Recipe| RMS
+    INGR_EP --> SS
+    RECIPE_EP --> SS
+    SS -->|Convert Units| UC
+    SS -->|Cache Lookup| REDIS
+    SS -->|DB Query| PR
+    PR --> PG
+    UC -->|Portion Weights| PR
+```
+
+### Key Components
+
+| Component         | Purpose                                                      |
+| ----------------- | ------------------------------------------------------------ |
+| ShoppingService   | Orchestrates caching, conversion, and pricing calculations   |
+| UnitConverter     | Converts between measurement units using Pint library        |
+| PricingRepository | PostgreSQL access for ingredient and food group pricing data |
+| Redis Cache       | 24-hour caching of computed pricing responses                |
+
+### Pricing Tiers
+
+| Tier | Source                    | Confidence | Description                          |
+| ---- | ------------------------- | ---------- | ------------------------------------ |
+| 1    | Direct Ingredient Pricing | 0.95       | Exact price per gram for ingredient  |
+| 2    | Food Group Average        | 0.60       | Average price for ingredient's group |
+
+---
+
+## 2. API Endpoints
+
+### Ingredient Shopping Info
+
+**Endpoint:** `GET /api/v1/recipe-scraper/ingredients/{ingredient_id}/shopping-info`
+
+Retrieves pricing data for a single ingredient with optional quantity scaling.
+
+| Parameter     | Type  | Required | Description                                  |
+| ------------- | ----- | -------- | -------------------------------------------- |
+| ingredient_id | int   | Yes      | Ingredient database identifier               |
+| amount        | float | No       | Quantity amount (must be with measurement)   |
+| measurement   | enum  | No       | Unit of measurement (G, KG, CUP, TBSP, etc.) |
+
+**Response (200 OK):**
+
+```json
+{
+  "ingredientName": "flour",
+  "quantity": { "amount": 250.0, "measurement": "G" },
+  "estimatedPrice": "0.45",
+  "priceConfidence": 0.95,
+  "dataSource": "USDA_FVP",
+  "currency": "USD"
+}
+```
+
+**Notes:**
+
+- If no quantity is provided, returns price for 100 grams
+- Both `amount` and `measurement` must be provided together, or neither
+
+### Recipe Shopping Info
+
+**Endpoint:** `GET /api/v1/recipe-scraper/recipes/{recipeId}/shopping-info`
+
+Aggregates pricing data for all ingredients in a recipe.
+
+| Parameter | Type | Required | Description       |
+| --------- | ---- | -------- | ----------------- |
+| recipeId  | int  | Yes      | Recipe identifier |
+
+**Response Codes:**
+
+- **200 OK** - All ingredients have pricing data
+- **206 Partial Content** - Some ingredients missing prices (X-Partial-Content header lists missing IDs)
+- **404 Not Found** - Recipe not found
+- **503 Service Unavailable** - Recipe Management Service unavailable
+
+**Response (200 OK):**
+
+```json
+{
+  "recipeId": 123,
+  "ingredients": {
+    "flour": {
+      "ingredientName": "flour",
+      "quantity": { "amount": 250.0, "measurement": "G" },
+      "estimatedPrice": "0.45",
+      "priceConfidence": 0.95,
+      "dataSource": "USDA_FVP",
+      "currency": "USD"
+    },
+    "butter": {
+      "ingredientName": "butter",
+      "quantity": { "amount": 227.0, "measurement": "G" },
+      "estimatedPrice": "3.50",
+      "priceConfidence": 0.95,
+      "dataSource": "USDA_FVP",
+      "currency": "USD"
+    }
+  },
+  "totalEstimatedCost": "3.95",
+  "missingIngredients": null
+}
+```
+
+**Response (206 Partial Content):**
+
+```http
+HTTP/1.1 206 Partial Content
+X-Partial-Content: 105,108
+```
+
+```json
+{
+  "recipeId": 123,
+  "ingredients": {...},
+  "totalEstimatedCost": "2.50",
+  "missingIngredients": [105, 108]
+}
+```
+
+---
+
+## 3. Processing Flow
+
+### Single Ingredient Lookup
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant EP as Endpoint
+    participant SS as ShoppingService
+    participant RC as Redis Cache
+    participant UC as UnitConverter
+    participant PR as PricingRepository
+    participant DB as PostgreSQL
+
+    C->>EP: GET /ingredients/101/shopping-info?amount=1&measurement=CUP
+    EP->>EP: Validate params (amount + measurement together)
+    EP->>SS: get_ingredient_shopping_info(101, {1, CUP})
+
+    SS->>RC: GET shopping:101:1.0:CUP
+    alt Cache Hit
+        RC-->>SS: Cached IngredientShoppingInfoResponse
+    else Cache Miss
+        RC-->>SS: null
+
+        SS->>PR: get_ingredient_details(101)
+        PR->>DB: SELECT name, food_group FROM ingredients
+        DB-->>PR: {name: "flour", food_group: "GRAINS"}
+        PR-->>SS: Ingredient details
+
+        SS->>UC: to_grams({1, CUP}, "flour")
+        UC->>PR: get_portion_weight("flour", "CUP")
+        PR->>DB: SELECT gram_weight FROM ingredient_portions
+        DB-->>PR: 125.0g
+        UC-->>SS: 125.0 grams
+
+        SS->>PR: get_ingredient_pricing(101)
+        PR->>DB: Tier 1: SELECT price_per_gram FROM ingredient_pricing
+        alt Tier 1: Direct Pricing Found
+            DB-->>PR: price_per_gram, data_source
+            PR-->>SS: PricingData (confidence: 0.95)
+        else Tier 2: Food Group Fallback
+            DB-->>PR: null
+            SS->>PR: get_food_group_pricing("GRAINS")
+            PR->>DB: SELECT avg_price_per_gram FROM food_group_pricing
+            DB-->>PR: avg_price_per_gram
+            PR-->>SS: PricingData (confidence: 0.60)
+        end
+
+        SS->>SS: Calculate: price = grams × price_per_gram
+        SS->>RC: SETEX shopping:101:1.0:CUP (TTL: 24h)
+    end
+
+    SS-->>EP: IngredientShoppingInfoResponse
+    EP-->>C: 200 OK + JSON
+```
+
+### Recipe Aggregation Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant EP as Endpoint
+    participant RMS as Recipe Management Service
+    participant SS as ShoppingService
+    participant RC as Redis Cache
+    participant PR as PricingRepository
+
+    C->>EP: GET /recipes/123/shopping-info
+    EP->>RMS: GET /recipes/123
+    RMS-->>EP: Recipe with ingredients list
+
+    EP->>SS: get_recipe_shopping_info(123, [ingredients])
+
+    loop For each ingredient
+        SS->>SS: get_ingredient_shopping_info(id, quantity)
+        Note over SS: Two-tier lookup per ingredient
+    end
+
+    SS->>SS: Sum prices for totalEstimatedCost
+    SS->>SS: Collect missing ingredients
+
+    SS-->>EP: RecipeShoppingInfoResponse
+
+    alt All ingredients have prices
+        EP-->>C: 200 OK
+    else Some ingredients missing prices
+        EP-->>C: 206 Partial Content + X-Partial-Content header
+    end
+```
+
+---
+
+## 4. Two-Tier Pricing Strategy
+
+The ShoppingService uses a two-tier approach to maximize pricing data availability while indicating confidence levels.
+
+```mermaid
+flowchart TD
+    START[Ingredient Query] --> CACHE{Cache<br/>Lookup}
+
+    CACHE -->|Hit| RETURN[Return Cached Data]
+    CACHE -->|Miss| CONVERT[Convert to Grams]
+
+    CONVERT --> TIER1{Tier 1:<br/>Direct Pricing?}
+
+    TIER1 -->|Yes| CALC1[Calculate Price<br/>Confidence: 0.95]
+    TIER1 -->|No| TIER2{Tier 2:<br/>Food Group Pricing?}
+
+    TIER2 -->|Yes| CALC2[Calculate Price<br/>Confidence: 0.60]
+    TIER2 -->|No| NO_PRICE[Return null price]
+
+    CALC1 --> CACHE_STORE[Cache & Return]
+    CALC2 --> CACHE_STORE
+    NO_PRICE --> MARK_MISSING[Mark as Missing]
+
+    CACHE_STORE --> RETURN
+    MARK_MISSING --> RETURN
+
+    style TIER1 fill:#90EE90
+    style TIER2 fill:#F0E68C
+    style NO_PRICE fill:#FFB6C1
+```
+
+### Confidence Scores
+
+| Tier | Confidence | Description                                        |
+| ---- | ---------- | -------------------------------------------------- |
+| 1    | 0.95       | Direct ingredient pricing - highly accurate        |
+| 2    | 0.60       | Food group average - less accurate but informative |
+| -    | null       | No pricing data available                          |
+
+### Data Sources
+
+| Source    | Description                              |
+| --------- | ---------------------------------------- |
+| USDA_FVP  | USDA Fruit and Vegetable Prices          |
+| USDA_FMAP | USDA Food Marketing and Analysis Program |
+
+---
+
+## 5. Unit Conversion
+
+The UnitConverter converts ingredient quantities to grams for price calculation using a three-tier strategy:
+
+```mermaid
+flowchart TD
+    START[Receive Quantity] --> CHECK{What type<br/>of unit?}
+
+    CHECK -->|Weight Unit<br/>G, KG, OZ, LB| PINT[Pint Library<br/>Direct Conversion]
+    PINT --> DONE[Return Grams]
+
+    CHECK -->|Volume Unit<br/>CUP, TBSP, TSP, ML, L| VOL_DB[DB: Get Portion Weight]
+    VOL_DB --> VOL_FOUND{Found?}
+    VOL_FOUND -->|Yes| DONE
+    VOL_FOUND -->|No| VOL_FALL[Fallback: 1 g/ml density]
+    VOL_FALL --> DONE
+
+    CHECK -->|Count Unit<br/>PIECE, CLOVE, etc.| COUNT_DB[DB: Get Portion Weight]
+    COUNT_DB --> COUNT_FOUND{Found?}
+    COUNT_FOUND -->|Yes| DONE
+    COUNT_FOUND -->|No| COUNT_ERR[Raise ConversionError]
+
+    style PINT fill:#90EE90
+    style VOL_FALL fill:#FFE4B5
+    style COUNT_ERR fill:#FFB6C1
+```
+
+### Supported Units
+
+| Category | Units                        | Conversion Method            |
+| -------- | ---------------------------- | ---------------------------- |
+| Weight   | G, KG, OZ, LB                | Direct Pint conversion       |
+| Volume   | CUP, TBSP, TSP, ML, L, FL_OZ | DB lookup → 1 g/ml fallback  |
+| Count    | PIECE, CLOVE, SLICE, etc.    | DB lookup → Error if missing |
+
+---
+
+## 6. Caching Strategy
+
+```mermaid
+flowchart TB
+    subgraph "Cache Layer"
+        direction TB
+        KEY["Cache Key: shopping:{ingredient_id}:{amount}:{unit}"]
+        TTL["TTL: 24 hours (86,400 seconds)"]
+        DATA["Stores: Complete IngredientShoppingInfoResponse"]
+    end
+
+    subgraph "Cache Flow"
+        direction LR
+        REQ[Request] --> LOOKUP[Cache Lookup]
+        LOOKUP -->|Hit| RESPONSE[Response]
+        LOOKUP -->|Miss| CALC[Calculate Price]
+        CALC --> CACHE_SET[Cache Response]
+        CACHE_SET --> RESPONSE
+    end
+
+    style KEY fill:#E6E6FA
+    style TTL fill:#E6E6FA
+    style DATA fill:#E6E6FA
+```
+
+### Key Design Decisions
+
+1. **Computed Response Caching**: Cache stores the complete response including calculated price
+
+   - Different quantities result in different cache entries
+   - Avoids recalculation for repeated identical requests
+
+2. **24-hour TTL**: Shorter than nutrition (30 days) because:
+
+   - Prices are more volatile than nutritional data
+   - Still provides significant performance benefit
+
+3. **Graceful Degradation**: Cache failures don't fail requests
+   - Falls back to direct database calculation
+   - Errors logged but not propagated
+
+### Cache Key Format
+
+```text
+shopping:{ingredient_id}:{amount}:{unit}
+
+Examples:
+- shopping:101:100.0:G
+- shopping:101:1.0:CUP
+- shopping:102:2.0:TBSP
+```
+
+---
+
+## 7. Database Schema
+
+```mermaid
+erDiagram
+    ingredients ||--o| ingredient_pricing : has
+    ingredients ||--o| nutrition_profiles : has
+    nutrition_profiles ||--|| food_group_pricing : references
+    ingredients ||--o{ ingredient_portions : has
+
+    ingredients {
+        bigint ingredient_id PK
+        varchar name UK
+        int fdc_id
+        text usda_food_description
+    }
+
+    nutrition_profiles {
+        bigint nutrition_profile_id PK
+        bigint ingredient_id FK
+        varchar food_group "GRAINS, DAIRY, etc."
+        decimal serving_size_g
+    }
+
+    ingredient_pricing {
+        bigint pricing_id PK
+        bigint ingredient_id FK "UNIQUE"
+        decimal price_per_gram
+        varchar data_source "USDA_FVP, USDA_FMAP"
+        timestamp updated_at
+    }
+
+    food_group_pricing {
+        bigint food_group_pricing_id PK
+        varchar food_group UK "GRAINS, DAIRY, etc."
+        decimal avg_price_per_gram
+        varchar data_source
+        timestamp updated_at
+    }
+
+    ingredient_portions {
+        bigint id PK
+        bigint ingredient_id FK
+        varchar portion_description
+        varchar unit
+        decimal gram_weight
+    }
+```
+
+### Query Patterns
+
+**Tier 1 - Direct Ingredient Pricing:**
+
+```sql
+SELECT price_per_gram, data_source
+FROM recipe_manager.ingredient_pricing
+WHERE ingredient_id = $1
+```
+
+**Tier 2 - Food Group Fallback:**
+
+```sql
+SELECT fgp.avg_price_per_gram, fgp.data_source
+FROM recipe_manager.food_group_pricing fgp
+JOIN recipe_manager.nutrition_profiles np
+    ON fgp.food_group = np.food_group
+WHERE np.ingredient_id = $1
+```
+
+---
+
+## 8. Error Handling
+
+### Error Codes Reference
+
+| HTTP Status | Error Code              | Scenario                                         |
+| ----------- | ----------------------- | ------------------------------------------------ |
+| 200         | -                       | Success - all pricing data found                 |
+| 206         | -                       | Partial Content - some ingredients missing price |
+| 400         | INVALID_QUANTITY_PARAMS | Only amount or only measurement provided         |
+| 404         | INGREDIENT_NOT_FOUND    | Ingredient not in database                       |
+| 422         | CONVERSION_ERROR        | Unit conversion failed (e.g., PIECE without DB)  |
+| 503         | SERVICE_UNAVAILABLE     | Recipe Management Service unavailable            |
+
+### Error Response Format
+
+```json
+{
+  "error": "HTTP_ERROR",
+  "message": "{'error': 'INVALID_QUANTITY_PARAMS', 'message': 'Both amount and measurement must be provided together'}",
+  "details": null,
+  "request_id": "abc-123"
+}
+```
+
+### Partial Content Response
+
+When recipe aggregation encounters ingredients without pricing:
+
+```http
+HTTP/1.1 206 Partial Content
+X-Partial-Content: 103,105
+
+{
+  "recipeId": 123,
+  "ingredients": {...},
+  "totalEstimatedCost": "5.25",
+  "missingIngredients": [103, 105]
+}
+```
+
+The `X-Partial-Content` header contains comma-separated ingredient IDs that could not be priced.
+
+---
+
+## 9. Data Attribution
+
+Pricing information in this service is derived from USDA data sources:
+
+> **U.S. Department of Agriculture, Economic Research Service.**
+>
+> - Fruit and Vegetable Prices (FVP)
+> - Food Marketing and Analysis Program (FMAP)
+
+### Notes on Pricing Data
+
+- Prices are estimates based on national averages
+- Actual grocery prices vary by location, season, and retailer
+- Food group averages provide rough estimates when direct pricing unavailable
+- Currency is USD; international pricing not currently supported
+
+### Data Freshness
+
+- Pricing data is updated periodically from USDA sources
+- Cache TTL of 24 hours balances freshness with performance
+- `updated_at` timestamps track when pricing data was last refreshed

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from app.services.popular.service import PopularRecipesService
     from app.services.recipe_management.client import RecipeManagementClient
     from app.services.scraping.service import RecipeScraperService
+    from app.services.shopping.service import ShoppingService
 
 
 async def get_scraper_service(request: Request) -> RecipeScraperService:
@@ -170,3 +171,26 @@ async def get_redis_cache_client() -> Redis[bytes] | None:
         return await get_cache_client()
     except Exception:
         return None
+
+
+async def get_shopping_service(request: Request) -> ShoppingService:
+    """Get the shopping service from app state.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        Initialized ShoppingService.
+
+    Raises:
+        HTTPException: 503 if service is not initialized.
+    """
+    service: ShoppingService | None = getattr(
+        request.app.state, "shopping_service", None
+    )
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Shopping service not available",
+        )
+    return service

--- a/src/app/api/v1/endpoints/ingredients.py
+++ b/src/app/api/v1/endpoints/ingredients.py
@@ -11,7 +11,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.api.dependencies import get_allergen_service, get_nutrition_service
+from app.api.dependencies import (
+    get_allergen_service,
+    get_nutrition_service,
+    get_shopping_service,
+)
 from app.auth.dependencies import CurrentUser, RequirePermissions
 from app.auth.permissions import Permission
 from app.observability.logging import get_logger
@@ -19,9 +23,12 @@ from app.schemas.allergen import IngredientAllergenResponse
 from app.schemas.enums import IngredientUnit
 from app.schemas.ingredient import Quantity
 from app.schemas.nutrition import IngredientNutritionalInfoResponse
+from app.schemas.shopping import IngredientShoppingInfoResponse
 from app.services.allergen.service import AllergenService  # noqa: TC001
 from app.services.nutrition.exceptions import ConversionError
 from app.services.nutrition.service import NutritionService  # noqa: TC001
+from app.services.shopping.exceptions import IngredientNotFoundError
+from app.services.shopping.service import ShoppingService  # noqa: TC001
 
 
 logger = get_logger(__name__)
@@ -282,6 +289,176 @@ async def get_ingredient_allergens(
         ingredient_id=ingredient_id,
         allergen_count=len(result.allergens),
         data_source=data_source_str,
+    )
+
+    return result
+
+
+@router.get(
+    "/ingredients/{ingredient_id}/shopping-info",
+    response_model=IngredientShoppingInfoResponse,
+    summary="Get shopping information for an ingredient",
+    description=(
+        "Retrieves shopping information for a specific ingredient, including "
+        "estimated prices, availability, and quantity conversions for grocery shopping. "
+        "Uses a two-tier pricing lookup: direct ingredient pricing, then food group averages."
+    ),
+    responses={
+        400: {
+            "description": "Invalid parameters (amount/measurement must be provided together)",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "INVALID_QUANTITY_PARAMS",
+                        "message": (
+                            "Both 'amount' and 'measurement' must be provided "
+                            "together, or neither"
+                        ),
+                    }
+                }
+            },
+        },
+        404: {
+            "description": "Ingredient not found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "INGREDIENT_NOT_FOUND",
+                        "message": "Ingredient not found: 12345",
+                    }
+                }
+            },
+        },
+        422: {
+            "description": "Invalid measurement unit or conversion failed",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "CONVERSION_ERROR",
+                        "message": "Unable to convert quantity: Cannot convert PIECE to grams",
+                    }
+                }
+            },
+        },
+        503: {
+            "description": "Shopping service unavailable",
+        },
+    },
+)
+async def get_ingredient_shopping_info(
+    ingredient_id: int,
+    user: Annotated[CurrentUser, Depends(RequirePermissions(Permission.RECIPE_READ))],
+    shopping_service: Annotated[ShoppingService, Depends(get_shopping_service)],
+    amount: Annotated[
+        float | None,
+        Query(
+            gt=0,
+            description="Quantity amount (must be provided with measurement)",
+        ),
+    ] = None,
+    measurement: Annotated[
+        IngredientUnit | None,
+        Query(
+            description="Unit of measurement (must be provided with amount)",
+        ),
+    ] = None,
+) -> IngredientShoppingInfoResponse:
+    """Get shopping information for an ingredient.
+
+    This endpoint retrieves pricing data using a two-tier lookup strategy:
+    1. Direct ingredient pricing from ingredient_pricing table
+    2. Food group average pricing from food_group_pricing table (fallback)
+
+    If amount and measurement are provided, the price is calculated for that
+    quantity. Otherwise, returns price information for 100 grams.
+
+    Args:
+        ingredient_id: The ingredient database ID.
+        user: Authenticated user with RECIPE_READ permission.
+        shopping_service: Service for fetching shopping data.
+        amount: Optional quantity amount for price calculation.
+        measurement: Optional unit of measurement for price calculation.
+
+    Returns:
+        Shopping information for the ingredient.
+
+    Raises:
+        HTTPException: 400 if only one of amount/measurement provided.
+        HTTPException: 404 if ingredient not found.
+        HTTPException: 422 if unit conversion fails.
+    """
+    # Validate that amount and measurement are provided together
+    if (amount is None) != (measurement is None):
+        logger.warning(
+            "Invalid quantity parameters for shopping info",
+            ingredient_id=ingredient_id,
+            amount=amount,
+            measurement=measurement,
+            user_id=user.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "INVALID_QUANTITY_PARAMS",
+                "message": (
+                    "Both 'amount' and 'measurement' must be provided together, "
+                    "or neither"
+                ),
+            },
+        )
+
+    # Build quantity - default to 100g if not specified
+    quantity: Quantity | None = None
+    if amount is not None and measurement is not None:
+        quantity = Quantity(amount=amount, measurement=measurement)
+
+    logger.info(
+        "Fetching shopping info",
+        ingredient_id=ingredient_id,
+        quantity_amount=quantity.amount if quantity else None,
+        quantity_measurement=str(quantity.measurement) if quantity else None,
+        user_id=user.id,
+    )
+
+    # Get shopping data from service
+    try:
+        result = await shopping_service.get_ingredient_shopping_info(
+            ingredient_id=ingredient_id,
+            quantity=quantity,
+        )
+    except IngredientNotFoundError:
+        logger.info(
+            "Ingredient not found for shopping info",
+            ingredient_id=ingredient_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "INGREDIENT_NOT_FOUND",
+                "message": f"Ingredient not found: {ingredient_id}",
+            },
+        ) from None
+    except ConversionError as e:
+        logger.warning(
+            "Unit conversion failed for shopping info",
+            ingredient_id=ingredient_id,
+            measurement=str(measurement) if measurement else None,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "CONVERSION_ERROR",
+                "message": f"Unable to convert quantity: {e}",
+            },
+        ) from None
+
+    logger.debug(
+        "Returning shopping info",
+        ingredient_id=ingredient_id,
+        ingredient_name=result.ingredient_name,
+        has_price=result.estimated_price is not None,
+        data_source=result.data_source,
     )
 
     return result

--- a/src/app/database/repositories/__init__.py
+++ b/src/app/database/repositories/__init__.py
@@ -1,6 +1,7 @@
 """Database repositories."""
 
 from app.database.repositories.nutrition import NutritionRepository
+from app.database.repositories.shopping import PricingRepository
 
 
-__all__ = ["NutritionRepository"]
+__all__ = ["NutritionRepository", "PricingRepository"]

--- a/src/app/database/repositories/shopping.py
+++ b/src/app/database/repositories/shopping.py
@@ -1,0 +1,229 @@
+"""Shopping/pricing data repository.
+
+Provides data access layer for ingredient pricing information stored in PostgreSQL.
+Uses a two-tier lookup strategy:
+- Tier 1: Direct ingredient pricing from ingredient_pricing table
+- Tier 2: Food group average pricing from food_group_pricing table
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from app.database.connection import get_database_pool
+from app.observability.logging import get_logger
+
+
+if TYPE_CHECKING:
+    from asyncpg import Pool, Record
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# Data Transfer Objects
+# =============================================================================
+
+
+class PricingData(BaseModel):
+    """Data transfer object for pricing information."""
+
+    price_per_100g: Decimal
+    currency: str
+    data_source: str
+    source_year: int | None = None
+    tier: int  # 1 for direct ingredient, 2 for food group fallback
+
+
+class IngredientDetails(BaseModel):
+    """Data transfer object for ingredient details needed for pricing lookup."""
+
+    ingredient_id: int
+    name: str
+    food_group: str | None = None
+
+
+# =============================================================================
+# Repository
+# =============================================================================
+
+
+class PricingRepository:
+    """Repository for pricing data access.
+
+    Uses raw asyncpg queries against the recipe_manager schema.
+    Implements two-tier pricing lookup strategy.
+    """
+
+    def __init__(self, pool: Pool | None = None) -> None:
+        """Initialize repository with optional connection pool.
+
+        Args:
+            pool: asyncpg connection pool. If None, uses global pool.
+        """
+        self._pool = pool
+
+    @property
+    def pool(self) -> Pool:
+        """Get the database connection pool."""
+        if self._pool is not None:
+            return self._pool
+        return get_database_pool()
+
+    async def get_price_by_ingredient_id(
+        self,
+        ingredient_id: int,
+    ) -> PricingData | None:
+        """Get pricing data for an ingredient by ID (Tier 1 lookup).
+
+        Args:
+            ingredient_id: The ingredient's database ID.
+
+        Returns:
+            PricingData if found, None otherwise.
+        """
+        query = """
+            SELECT
+                price_per_100g,
+                currency,
+                data_source,
+                source_year
+            FROM recipe_manager.ingredient_pricing
+            WHERE ingredient_id = $1
+        """
+
+        try:
+            async with self.pool.acquire() as conn:
+                row = await conn.fetchrow(query, ingredient_id)
+
+            if row is None:
+                return None
+
+            return self._row_to_pricing_data(row, tier=1)
+
+        except Exception as e:
+            # Handle missing table gracefully
+            error_msg = str(e).lower()
+            if "relation" in error_msg and "does not exist" in error_msg:
+                logger.debug(
+                    "ingredient_pricing table not found",
+                    ingredient_id=ingredient_id,
+                )
+                return None
+            raise
+
+    async def get_price_by_food_group(
+        self,
+        food_group: str,
+    ) -> PricingData | None:
+        """Get average pricing data for a food group (Tier 2 fallback).
+
+        Args:
+            food_group: The food group name (e.g., "VEGETABLES", "FRUITS").
+
+        Returns:
+            PricingData if found, None otherwise.
+        """
+        query = """
+            SELECT
+                avg_price_per_100g AS price_per_100g,
+                currency,
+                data_source
+            FROM recipe_manager.food_group_pricing
+            WHERE food_group = $1::recipe_manager.food_group_enum
+        """
+
+        try:
+            async with self.pool.acquire() as conn:
+                row = await conn.fetchrow(query, food_group)
+
+            if row is None:
+                return None
+
+            return self._row_to_pricing_data(row, tier=2)
+
+        except Exception as e:
+            # Handle missing table or invalid enum gracefully
+            error_msg = str(e).lower()
+            if "relation" in error_msg and "does not exist" in error_msg:
+                logger.debug(
+                    "food_group_pricing table not found",
+                    food_group=food_group,
+                )
+                return None
+            if "invalid input value for enum" in error_msg:
+                logger.debug(
+                    "Invalid food group enum value",
+                    food_group=food_group,
+                )
+                return None
+            raise
+
+    async def get_ingredient_details(
+        self,
+        ingredient_id: int,
+    ) -> IngredientDetails | None:
+        """Get ingredient details by ID (name and food group).
+
+        Args:
+            ingredient_id: The ingredient's database ID.
+
+        Returns:
+            IngredientDetails if found, None otherwise.
+        """
+        query = """
+            SELECT
+                i.ingredient_id,
+                i.name,
+                np.food_group
+            FROM recipe_manager.ingredients i
+            LEFT JOIN recipe_manager.nutrition_profiles np
+                ON np.ingredient_id = i.ingredient_id
+            WHERE i.ingredient_id = $1
+        """
+
+        try:
+            async with self.pool.acquire() as conn:
+                row = await conn.fetchrow(query, ingredient_id)
+
+            if row is None:
+                return None
+
+            return IngredientDetails(
+                ingredient_id=row["ingredient_id"],
+                name=row["name"],
+                food_group=row["food_group"],
+            )
+
+        except Exception as e:
+            # Handle missing table gracefully
+            error_msg = str(e).lower()
+            if "relation" in error_msg and "does not exist" in error_msg:
+                logger.debug(
+                    "ingredients table not found",
+                    ingredient_id=ingredient_id,
+                )
+                return None
+            raise
+
+    @staticmethod
+    def _row_to_pricing_data(row: Record, tier: int) -> PricingData:
+        """Convert database row to PricingData DTO.
+
+        Args:
+            row: Database record.
+            tier: Pricing tier (1 for direct, 2 for food group).
+
+        Returns:
+            PricingData object.
+        """
+        return PricingData(
+            price_per_100g=Decimal(str(row["price_per_100g"])),
+            currency=row["currency"],
+            data_source=row["data_source"],
+            source_year=row.get("source_year"),
+            tier=tier,
+        )

--- a/src/app/schemas/shopping.py
+++ b/src/app/schemas/shopping.py
@@ -18,7 +18,21 @@ class IngredientShoppingInfoResponse(APIResponse):
     quantity: Quantity = Field(..., description="Required quantity")
     estimated_price: str | None = Field(
         default=None,
-        description="Estimated price (None if unavailable)",
+        description="Estimated price in currency (None if unavailable)",
+    )
+    price_confidence: float | None = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description="Confidence score (0-1). Higher for direct pricing, lower for food group averages.",
+    )
+    data_source: str | None = Field(
+        default=None,
+        description="Data source for the price (e.g., 'USDA_FVP', 'USDA_FMAP')",
+    )
+    currency: str = Field(
+        default="USD",
+        description="Currency code for the estimated price",
     )
 
 

--- a/src/app/schemas/shopping.py
+++ b/src/app/schemas/shopping.py
@@ -45,3 +45,7 @@ class RecipeShoppingInfoResponse(APIResponse):
         description="Shopping info by ingredient name",
     )
     total_estimated_cost: str = Field(..., description="Total estimated cost")
+    missing_ingredients: list[int] | None = Field(
+        default=None,
+        description="List of ingredient IDs with unavailable pricing data",
+    )

--- a/src/app/services/shopping/__init__.py
+++ b/src/app/services/shopping/__init__.py
@@ -1,0 +1,9 @@
+"""Shopping service module.
+
+Provides pricing and shopping information for ingredients.
+"""
+
+from app.services.shopping.service import ShoppingService
+
+
+__all__ = ["ShoppingService"]

--- a/src/app/services/shopping/constants.py
+++ b/src/app/services/shopping/constants.py
@@ -1,0 +1,28 @@
+"""Constants for shopping service configuration.
+
+Contains:
+- Cache configuration for pricing data
+- Confidence scores for different pricing tiers
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Final
+
+
+# =============================================================================
+# Cache Configuration
+# =============================================================================
+
+SHOPPING_CACHE_KEY_PREFIX: Final[str] = "shopping"
+SHOPPING_CACHE_TTL_SECONDS: Final[int] = 24 * 60 * 60  # 24 hours
+
+
+# =============================================================================
+# Pricing Tier Confidence Scores
+# =============================================================================
+# Higher confidence for direct ingredient pricing, lower for food group averages
+
+TIER_1_CONFIDENCE: Final[Decimal] = Decimal("0.95")  # Direct ingredient pricing
+TIER_2_CONFIDENCE: Final[Decimal] = Decimal("0.60")  # Food group average

--- a/src/app/services/shopping/exceptions.py
+++ b/src/app/services/shopping/exceptions.py
@@ -1,0 +1,41 @@
+"""Exceptions for the shopping service.
+
+Custom exceptions for handling pricing lookup, caching, and calculation errors.
+"""
+
+from __future__ import annotations
+
+
+class ShoppingServiceError(Exception):
+    """Base exception for shopping service errors."""
+
+    def __init__(self, message: str, ingredient_id: int | None = None) -> None:
+        """Initialize the exception.
+
+        Args:
+            message: Error message.
+            ingredient_id: Optional ingredient ID related to the error.
+        """
+        self.ingredient_id = ingredient_id
+        super().__init__(message)
+
+
+class PriceNotAvailableError(ShoppingServiceError):
+    """Raised when pricing data is not available for an ingredient.
+
+    This occurs when neither Tier 1 (direct pricing) nor Tier 2 (food group)
+    lookups return pricing data. The service handles this gracefully by
+    returning null for estimated_price.
+    """
+
+
+class IngredientNotFoundError(ShoppingServiceError):
+    """Raised when the ingredient cannot be found in the recipe management service."""
+
+
+class CacheError(ShoppingServiceError):
+    """Raised when cache operations fail.
+
+    Cache errors should not propagate to the caller - the service
+    falls back to database lookup on cache failure.
+    """

--- a/src/app/services/shopping/service.py
+++ b/src/app/services/shopping/service.py
@@ -1,0 +1,346 @@
+"""Shopping service for retrieving ingredient pricing information.
+
+Provides methods for:
+- Single ingredient pricing lookup
+- Two-tier lookup strategy (direct ingredient → food group fallback)
+- Redis caching with 24-hour TTL
+- Unit conversion and price scaling
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import orjson
+
+from app.cache.redis import get_cache_client
+from app.database.repositories.nutrition import NutritionRepository
+from app.database.repositories.shopping import PricingRepository
+from app.observability.logging import get_logger
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.schemas.shopping import IngredientShoppingInfoResponse
+from app.services.nutrition.converter import UnitConverter
+from app.services.nutrition.exceptions import ConversionError
+from app.services.shopping.constants import (
+    SHOPPING_CACHE_KEY_PREFIX,
+    SHOPPING_CACHE_TTL_SECONDS,
+    TIER_1_CONFIDENCE,
+    TIER_2_CONFIDENCE,
+)
+from app.services.shopping.exceptions import IngredientNotFoundError
+
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = get_logger(__name__)
+
+
+class ShoppingService:
+    """Service for retrieving shopping/pricing information.
+
+    Orchestrates:
+    1. Redis cache lookups
+    2. PostgreSQL database queries via PricingRepository
+    3. Two-tier pricing lookup (direct ingredient → food group fallback)
+    4. Unit conversion to grams
+    5. Price calculation based on quantity
+    6. Transformation to API response schemas
+
+    Cache Strategy:
+    - Cache key: "shopping:{ingredient_id}:{amount}:{unit}"
+    - TTL: 24 hours
+    - Caches computed responses including price
+    """
+
+    def __init__(
+        self,
+        cache_client: Redis[bytes] | None = None,
+        repository: PricingRepository | None = None,
+        nutrition_repository: NutritionRepository | None = None,
+    ) -> None:
+        """Initialize the service.
+
+        Args:
+            cache_client: Optional Redis client for caching.
+            repository: Optional PricingRepository instance.
+            nutrition_repository: Optional NutritionRepository for unit conversion.
+        """
+        self._cache_client = cache_client
+        self._repository = repository
+        self._nutrition_repository = nutrition_repository
+        self._converter: UnitConverter | None = None
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize service resources.
+
+        Called during application startup. Sets up repository if not injected.
+        """
+        if self._cache_client is None:
+            try:
+                self._cache_client = await get_cache_client()
+            except Exception:
+                logger.warning("Redis not available, caching disabled")
+
+        if self._repository is None:
+            self._repository = PricingRepository()
+
+        if self._nutrition_repository is None:
+            self._nutrition_repository = NutritionRepository()
+
+        # Create converter with nutrition repository for portion weight lookups
+        self._converter = UnitConverter(nutrition_repository=self._nutrition_repository)
+
+        self._initialized = True
+        logger.info("ShoppingService initialized")
+
+    async def shutdown(self) -> None:
+        """Cleanup service resources.
+
+        Called during application shutdown.
+        """
+        self._initialized = False
+        logger.info("ShoppingService shutdown")
+
+    async def get_ingredient_shopping_info(
+        self,
+        ingredient_id: int,
+        quantity: Quantity | None = None,
+    ) -> IngredientShoppingInfoResponse:
+        """Get shopping/pricing information for a single ingredient.
+
+        Args:
+            ingredient_id: Database ID of the ingredient.
+            quantity: Optional quantity with amount and unit for price calculation.
+                      If not provided, returns price per 100g.
+
+        Returns:
+            Shopping information with estimated price.
+
+        Raises:
+            IngredientNotFoundError: If ingredient doesn't exist.
+            ConversionError: If unit conversion fails.
+        """
+        if not self._initialized or self._repository is None:
+            msg = "ShoppingService not initialized"
+            logger.error(msg)
+            raise RuntimeError(msg)
+
+        # Default to 100g if no quantity specified
+        if quantity is None:
+            quantity = Quantity(amount=100.0, measurement=IngredientUnit.G)
+
+        # Check cache first
+        cache_key = self._make_cache_key(ingredient_id, quantity)
+        cached = await self._get_from_cache(cache_key)
+        if cached is not None:
+            logger.debug(
+                "Cache hit for shopping info",
+                ingredient_id=ingredient_id,
+                cache_key=cache_key,
+            )
+            return cached
+
+        # Get ingredient details (name and food_group)
+        ingredient = await self._repository.get_ingredient_details(ingredient_id)
+        if ingredient is None:
+            msg = f"Ingredient not found: {ingredient_id}"
+            raise IngredientNotFoundError(msg, ingredient_id=ingredient_id)
+
+        # Try Tier 1: Direct ingredient pricing
+        pricing = await self._repository.get_price_by_ingredient_id(ingredient_id)
+
+        # Fallback to Tier 2: Food group pricing
+        if pricing is None and ingredient.food_group:
+            pricing = await self._repository.get_price_by_food_group(
+                ingredient.food_group
+            )
+
+        # Calculate price if pricing data available
+        estimated_price: str | None = None
+        price_confidence: float | None = None
+        data_source: str | None = None
+        currency = "USD"
+
+        if pricing is not None:
+            # Convert quantity to grams
+            try:
+                grams = await self._convert_to_grams(quantity, ingredient.name)
+            except ConversionError:
+                logger.warning(
+                    "Unit conversion failed for shopping info",
+                    ingredient_id=ingredient_id,
+                    ingredient_name=ingredient.name,
+                    unit=str(quantity.measurement),
+                )
+                raise
+
+            # Calculate price: (grams / 100) * price_per_100g
+            price = self._calculate_price(pricing.price_per_100g, grams)
+            estimated_price = f"{price:.2f}"
+            currency = pricing.currency
+            data_source = pricing.data_source
+
+            # Set confidence based on tier
+            if pricing.tier == 1:
+                price_confidence = float(TIER_1_CONFIDENCE)
+            else:
+                price_confidence = float(TIER_2_CONFIDENCE)
+
+            logger.debug(
+                "Price calculated",
+                ingredient_id=ingredient_id,
+                ingredient_name=ingredient.name,
+                tier=pricing.tier,
+                price=estimated_price,
+                grams=float(grams),
+            )
+        else:
+            logger.debug(
+                "No pricing data available",
+                ingredient_id=ingredient_id,
+                ingredient_name=ingredient.name,
+                food_group=ingredient.food_group,
+            )
+
+        # Build response
+        response = IngredientShoppingInfoResponse(
+            ingredient_name=ingredient.name,
+            quantity=quantity,
+            estimated_price=estimated_price,
+            price_confidence=price_confidence,
+            data_source=data_source,
+            currency=currency,
+        )
+
+        # Cache the result
+        await self._cache_result(cache_key, response)
+
+        return response
+
+    async def _convert_to_grams(
+        self,
+        quantity: Quantity,
+        ingredient_name: str,
+    ) -> Decimal:
+        """Convert quantity to grams using UnitConverter.
+
+        Args:
+            quantity: Quantity to convert.
+            ingredient_name: Ingredient name for portion weight lookup.
+
+        Returns:
+            Amount in grams.
+
+        Raises:
+            ConversionError: If conversion fails.
+        """
+        if self._converter is None:
+            # Fallback: assume 1:1 for grams, rough estimates for others
+            if quantity.measurement == IngredientUnit.G:
+                return Decimal(str(quantity.amount))
+            if quantity.measurement == IngredientUnit.KG:
+                return Decimal(str(quantity.amount)) * Decimal(1000)
+            # Default to 100g per unit for unknown conversions
+            return Decimal(str(quantity.amount)) * Decimal(100)
+
+        return await self._converter.to_grams(quantity, ingredient_name)
+
+    def _calculate_price(
+        self,
+        price_per_100g: Decimal,
+        grams: Decimal,
+    ) -> Decimal:
+        """Calculate price for a given quantity in grams.
+
+        Args:
+            price_per_100g: Price per 100 grams.
+            grams: Quantity in grams.
+
+        Returns:
+            Calculated price.
+        """
+        return (grams / Decimal(100)) * price_per_100g
+
+    def _make_cache_key(
+        self,
+        ingredient_id: int,
+        quantity: Quantity,
+    ) -> str:
+        """Generate cache key for shopping info.
+
+        Args:
+            ingredient_id: Ingredient database ID.
+            quantity: Quantity for the lookup.
+
+        Returns:
+            Cache key string.
+        """
+        return f"{SHOPPING_CACHE_KEY_PREFIX}:{ingredient_id}:{quantity.amount}:{quantity.measurement}"
+
+    async def _get_from_cache(
+        self,
+        cache_key: str,
+    ) -> IngredientShoppingInfoResponse | None:
+        """Get cached shopping info.
+
+        Args:
+            cache_key: Cache key to look up.
+
+        Returns:
+            Cached response or None if not found.
+        """
+        if self._cache_client is None:
+            return None
+
+        try:
+            data = await self._cache_client.get(cache_key)
+            if data is None:
+                return None
+
+            parsed = orjson.loads(data)
+            return IngredientShoppingInfoResponse.model_validate(parsed)
+
+        except Exception as e:
+            logger.warning(
+                "Cache read failed",
+                cache_key=cache_key,
+                error=str(e),
+            )
+            return None
+
+    async def _cache_result(
+        self,
+        cache_key: str,
+        response: IngredientShoppingInfoResponse,
+    ) -> None:
+        """Cache shopping info response.
+
+        Args:
+            cache_key: Cache key to store under.
+            response: Response to cache.
+        """
+        if self._cache_client is None:
+            return
+
+        try:
+            data = orjson.dumps(response.model_dump(by_alias=True))
+            await self._cache_client.setex(
+                cache_key,
+                SHOPPING_CACHE_TTL_SECONDS,
+                data,
+            )
+            logger.debug(
+                "Cached shopping info",
+                cache_key=cache_key,
+                ttl=SHOPPING_CACHE_TTL_SECONDS,
+            )
+        except Exception as e:
+            logger.warning(
+                "Cache write failed",
+                cache_key=cache_key,
+                error=str(e),
+            )

--- a/tests/e2e/test_ingredients_endpoint.py
+++ b/tests/e2e/test_ingredients_endpoint.py
@@ -1,0 +1,296 @@
+"""End-to-end tests for the ingredients endpoints.
+
+Tests verify the full ingredient shopping info flow with authentication
+and service mocking.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.dependencies import get_shopping_service
+from app.auth.providers import set_auth_provider, shutdown_auth_provider
+from app.auth.providers.header import HeaderAuthProvider
+from app.core.config import Settings
+from app.core.config.settings import (
+    ApiSettings,
+    AppSettings,
+    AuthSettings,
+    LoggingSettings,
+    ObservabilitySettings,
+    RateLimitingSettings,
+    RedisSettings,
+    ServerSettings,
+)
+from app.core.config.settings import (
+    get_settings as _get_settings,
+)
+from app.factory import create_app
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.schemas.shopping import IngredientShoppingInfoResponse
+
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from fastapi import FastAPI
+
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def ingredients_test_settings(redis_url: str) -> Settings:
+    """Create test settings for ingredient tests."""
+    parts = redis_url.replace("redis://", "").split(":")
+    redis_host = parts[0]
+    redis_port = int(parts[1])
+
+    return Settings(
+        APP_ENV="test",
+        JWT_SECRET_KEY="e2e-test-jwt-secret-key-for-ingredients",
+        REDIS_PASSWORD="",
+        app=AppSettings(
+            name="e2e-ingredient-test-app",
+            version="0.0.1-e2e",
+            debug=True,
+        ),
+        server=ServerSettings(
+            host="0.0.0.0",
+            port=8000,
+        ),
+        api=ApiSettings(
+            cors_origins=["http://localhost:3000"],
+        ),
+        auth=AuthSettings(
+            mode="header",
+        ),
+        redis=RedisSettings(
+            host=redis_host,
+            port=redis_port,
+            cache_db=0,
+            queue_db=1,
+            rate_limit_db=2,
+        ),
+        rate_limiting=RateLimitingSettings(
+            default="100/minute",
+            auth="10/minute",
+        ),
+        logging=LoggingSettings(
+            level="DEBUG",
+            format="json",
+        ),
+        observability=ObservabilitySettings(),
+    )
+
+
+@pytest.fixture
+async def ingredients_app(
+    ingredients_test_settings: Settings,
+) -> AsyncGenerator[FastAPI]:
+    """Create FastAPI app for ingredient tests."""
+    _get_settings.cache_clear()
+
+    provider = HeaderAuthProvider(
+        user_id_header="X-User-ID",
+        roles_header="X-User-Roles",
+        permissions_header="X-User-Permissions",
+        default_roles=[],
+    )
+    await provider.initialize()
+    set_auth_provider(provider)
+
+    try:
+        with (
+            patch(
+                "app.observability.metrics.get_settings",
+                return_value=ingredients_test_settings,
+            ),
+            patch(
+                "app.observability.tracing.get_settings",
+                return_value=ingredients_test_settings,
+            ),
+            patch(
+                "app.core.config.get_settings",
+                return_value=ingredients_test_settings,
+            ),
+            patch(
+                "app.core.config.settings.get_settings",
+                return_value=ingredients_test_settings,
+            ),
+        ):
+            app = create_app(ingredients_test_settings)
+            yield app
+    finally:
+        await shutdown_auth_provider()
+        _get_settings.cache_clear()
+
+
+@pytest.fixture
+async def ingredients_client(
+    ingredients_app: FastAPI,
+) -> AsyncGenerator[AsyncClient]:
+    """Create async HTTP client for ingredient testing."""
+    async with AsyncClient(
+        transport=ASGITransport(app=ingredients_app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+
+def auth_headers(
+    user_id: str = "e2e-test-user",
+    roles: str = "user",
+    permissions: str = "recipe:read",
+) -> dict[str, str]:
+    """Create auth headers for header-based authentication."""
+    return {
+        "Authorization": "Bearer ignored-in-header-mode",
+        "X-User-ID": user_id,
+        "X-User-Roles": roles,
+        "X-User-Permissions": permissions,
+    }
+
+
+class TestIngredientShoppingInfoE2E:
+    """E2E tests for the GET /ingredients/{id}/shopping-info endpoint."""
+
+    async def test_get_shopping_info_full_flow(
+        self,
+        ingredients_client: AsyncClient,
+    ) -> None:
+        """Test the complete shopping info retrieval flow."""
+        ingredient_id = 101
+
+        # Mock shopping result
+        mock_shopping_result = IngredientShoppingInfoResponse(
+            ingredient_name="flour",
+            quantity=Quantity(amount=100.0, measurement=IngredientUnit.G),
+            estimated_price="0.18",
+            price_confidence=0.85,
+            data_source="USDA_FVP",
+            currency="USD",
+        )
+
+        mock_shopping_service = MagicMock()
+        mock_shopping_service.get_ingredient_shopping_info = AsyncMock(
+            return_value=mock_shopping_result
+        )
+
+        # Override shopping service
+        ingredients_client._transport.app.dependency_overrides[get_shopping_service] = (
+            lambda: mock_shopping_service
+        )
+
+        try:
+            response = await ingredients_client.get(
+                f"/api/v1/recipe-scraper/ingredients/{ingredient_id}/shopping-info",
+                headers=auth_headers(),
+            )
+        finally:
+            ingredients_client._transport.app.dependency_overrides.pop(
+                get_shopping_service, None
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["ingredientName"] == "flour"
+        assert data["estimatedPrice"] == "0.18"
+        assert data["priceConfidence"] == 0.85
+        assert data["dataSource"] == "USDA_FVP"
+
+    async def test_get_shopping_info_with_quantity(
+        self,
+        ingredients_client: AsyncClient,
+    ) -> None:
+        """Test shopping info with custom quantity."""
+        ingredient_id = 101
+
+        mock_shopping_result = IngredientShoppingInfoResponse(
+            ingredient_name="flour",
+            quantity=Quantity(amount=250.0, measurement=IngredientUnit.G),
+            estimated_price="0.45",
+            price_confidence=0.85,
+            data_source="USDA_FVP",
+            currency="USD",
+        )
+
+        mock_shopping_service = MagicMock()
+        mock_shopping_service.get_ingredient_shopping_info = AsyncMock(
+            return_value=mock_shopping_result
+        )
+
+        ingredients_client._transport.app.dependency_overrides[get_shopping_service] = (
+            lambda: mock_shopping_service
+        )
+
+        try:
+            response = await ingredients_client.get(
+                f"/api/v1/recipe-scraper/ingredients/{ingredient_id}/shopping-info",
+                params={"amount": 250.0, "measurement": "G"},
+                headers=auth_headers(),
+            )
+        finally:
+            ingredients_client._transport.app.dependency_overrides.pop(
+                get_shopping_service, None
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["quantity"]["amount"] == 250.0
+        assert data["estimatedPrice"] == "0.45"
+
+    async def test_shopping_info_unauthorized(
+        self,
+        ingredients_client: AsyncClient,
+    ) -> None:
+        """Test that unauthenticated requests are rejected."""
+        response = await ingredients_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+        )
+
+        assert response.status_code == 401
+
+    async def test_shopping_info_forbidden_without_permission(
+        self,
+        ingredients_client: AsyncClient,
+    ) -> None:
+        """Test that requests without recipe:read permission are rejected."""
+        response = await ingredients_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+            headers=auth_headers(roles="", permissions="recipe:create"),
+        )
+
+        assert response.status_code == 403
+
+    async def test_shopping_info_invalid_params(
+        self,
+        ingredients_client: AsyncClient,
+    ) -> None:
+        """Test that partial quantity params return 400."""
+        # Mock shopping service (needed for dependency resolution)
+        mock_shopping_service = MagicMock()
+        ingredients_client._transport.app.dependency_overrides[get_shopping_service] = (
+            lambda: mock_shopping_service
+        )
+
+        try:
+            response = await ingredients_client.get(
+                "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+                params={"amount": 250.0},  # Missing measurement
+                headers=auth_headers(),
+            )
+        finally:
+            ingredients_client._transport.app.dependency_overrides.pop(
+                get_shopping_service, None
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "INVALID_QUANTITY_PARAMS" in data["message"]

--- a/tests/integration/api/test_ingredient_shopping_info_endpoint.py
+++ b/tests/integration/api/test_ingredient_shopping_info_endpoint.py
@@ -1,0 +1,321 @@
+"""Integration tests for ingredient shopping info API endpoint.
+
+Tests cover:
+- Full endpoint flow with mocked services
+- Authentication and authorization
+- Error handling with real middleware stack
+- Query parameter validation
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.dependencies import get_shopping_service
+from app.auth.dependencies import CurrentUser, get_current_user
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.schemas.shopping import IngredientShoppingInfoResponse
+from app.services.nutrition.exceptions import ConversionError
+from app.services.shopping.exceptions import IngredientNotFoundError
+
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from fastapi import FastAPI
+
+
+pytestmark = pytest.mark.integration
+
+
+# Mock user for authenticated tests
+MOCK_USER = CurrentUser(
+    id="test-user-123",
+    roles=["user"],
+    permissions=["recipe:read"],
+)
+
+
+@pytest.fixture
+def sample_shopping_result() -> IngredientShoppingInfoResponse:
+    """Create sample shopping result with all data."""
+    return IngredientShoppingInfoResponse(
+        ingredient_name="flour",
+        quantity=Quantity(amount=100.0, measurement=IngredientUnit.G),
+        estimated_price="0.18",
+        price_confidence=0.85,
+        data_source="USDA_FVP",
+        currency="USD",
+    )
+
+
+@pytest.fixture
+def mock_shopping_service(
+    sample_shopping_result: IngredientShoppingInfoResponse,
+) -> MagicMock:
+    """Create mock shopping service."""
+    mock = MagicMock()
+    mock.get_ingredient_shopping_info = AsyncMock(return_value=sample_shopping_result)
+    mock.initialize = AsyncMock()
+    mock.shutdown = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+async def ingredient_shopping_client(
+    app: FastAPI,
+    mock_shopping_service: MagicMock,
+) -> AsyncGenerator[AsyncClient]:
+    """Create client with shopping service mocked."""
+
+    async def mock_get_current_user() -> CurrentUser:
+        return MOCK_USER
+
+    async def mock_get_shopping() -> MagicMock:
+        return mock_shopping_service
+
+    # Set dependency overrides
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+    finally:
+        # Clean up dependency overrides
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_shopping_service, None)
+
+
+class TestGetIngredientShoppingInfoEndpoint:
+    """Integration tests for GET /ingredients/{id}/shopping-info endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_shopping_info_success(
+        self,
+        ingredient_shopping_client: AsyncClient,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 200 with shopping data."""
+        response = await ingredient_shopping_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info"
+        )
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["ingredientName"] == "flour"
+        assert data["estimatedPrice"] == "0.18"
+        assert data["priceConfidence"] == 0.85
+        assert data["dataSource"] == "USDA_FVP"
+
+        # Verify service was called
+        mock_shopping_service.get_ingredient_shopping_info.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_shopping_info_with_quantity(
+        self,
+        ingredient_shopping_client: AsyncClient,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should pass quantity parameters to service."""
+        response = await ingredient_shopping_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+            params={"amount": 250.0, "measurement": "G"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify service was called with quantity
+        call_args = mock_shopping_service.get_ingredient_shopping_info.call_args
+        assert call_args.kwargs["ingredient_id"] == 101
+        assert call_args.kwargs["quantity"].amount == 250.0
+        assert call_args.kwargs["quantity"].measurement == IngredientUnit.G
+
+    @pytest.mark.asyncio
+    async def test_returns_400_for_partial_quantity_params(
+        self,
+        ingredient_shopping_client: AsyncClient,
+    ) -> None:
+        """Should return 400 when only amount or measurement provided."""
+        # Only amount
+        response = await ingredient_shopping_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+            params={"amount": 250.0},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "INVALID_QUANTITY_PARAMS" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_returns_400_for_only_measurement(
+        self,
+        ingredient_shopping_client: AsyncClient,
+    ) -> None:
+        """Should return 400 when only measurement provided."""
+        response = await ingredient_shopping_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+            params={"measurement": "CUP"},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "INVALID_QUANTITY_PARAMS" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_ingredient(
+        self,
+        app: FastAPI,
+    ) -> None:
+        """Should return 404 when ingredient not found."""
+        mock_service = MagicMock()
+        mock_service.get_ingredient_shopping_info = AsyncMock(
+            side_effect=IngredientNotFoundError(
+                "Ingredient not found", ingredient_id=999
+            )
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/ingredients/999/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "INGREDIENT_NOT_FOUND" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_returns_422_for_conversion_error(
+        self,
+        app: FastAPI,
+    ) -> None:
+        """Should return 422 when unit conversion fails."""
+        mock_service = MagicMock()
+        mock_service.get_ingredient_shopping_info = AsyncMock(
+            side_effect=ConversionError("Cannot convert PIECE to G for flour")
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/ingredients/101/shopping-info",
+                    params={"amount": 2.0, "measurement": "PIECE"},
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "CONVERSION_ERROR" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_includes_middleware_headers(
+        self,
+        ingredient_shopping_client: AsyncClient,
+    ) -> None:
+        """Should include middleware headers in response."""
+        response = await ingredient_shopping_client.get(
+            "/api/v1/recipe-scraper/ingredients/101/shopping-info"
+        )
+
+        assert response.status_code == 200
+        assert "x-request-id" in response.headers
+        assert "x-process-time" in response.headers
+
+
+class TestIngredientShoppingInfoAuthentication:
+    """Tests for authentication on ingredient shopping info endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_401_without_auth(
+        self,
+        app: FastAPI,
+    ) -> None:
+        """Should return 401 when not authenticated."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/v1/recipe-scraper/ingredients/101/shopping-info"
+            )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_returns_403_without_permission(
+        self,
+        app: FastAPI,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 403 when user lacks required permission."""
+        user_without_permission = CurrentUser(
+            id="test-user-no-perms",
+            roles=[],
+            permissions=[],
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return user_without_permission
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_shopping_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/ingredients/101/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 403

--- a/tests/integration/api/test_recipe_shopping_info_endpoint.py
+++ b/tests/integration/api/test_recipe_shopping_info_endpoint.py
@@ -1,0 +1,481 @@
+"""Integration tests for recipe shopping info API endpoint.
+
+Tests cover:
+- Full endpoint flow with mocked services
+- Authentication and authorization
+- Error handling with real middleware stack
+- 206 Partial Content response handling
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.dependencies import get_recipe_management_client, get_shopping_service
+from app.auth.dependencies import CurrentUser, get_current_user
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.schemas.shopping import (
+    IngredientShoppingInfoResponse,
+    RecipeShoppingInfoResponse,
+)
+from app.services.recipe_management.exceptions import (
+    RecipeManagementNotFoundError,
+    RecipeManagementUnavailableError,
+)
+from app.services.recipe_management.schemas import (
+    IngredientUnit as RecipeIngredientUnit,
+)
+from app.services.recipe_management.schemas import (
+    RecipeDetailResponse,
+    RecipeIngredientResponse,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from fastapi import FastAPI
+
+
+pytestmark = pytest.mark.integration
+
+
+# Mock user for authenticated tests
+MOCK_USER = CurrentUser(
+    id="test-user-123",
+    roles=["user"],
+    permissions=["recipe:read"],
+)
+
+
+@pytest.fixture
+def sample_recipe_response() -> RecipeDetailResponse:
+    """Create sample recipe response with ingredients."""
+    return RecipeDetailResponse(
+        id=123,
+        title="Test Recipe",
+        slug="test-recipe",
+        description="A test recipe",
+        servings=4.0,
+        ingredients=[
+            RecipeIngredientResponse(
+                id=1,
+                ingredient_id=101,
+                ingredient_name="flour",
+                quantity=250.0,
+                unit=RecipeIngredientUnit.G,
+            ),
+            RecipeIngredientResponse(
+                id=2,
+                ingredient_id=102,
+                ingredient_name="sugar",
+                quantity=100.0,
+                unit=RecipeIngredientUnit.G,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def sample_shopping_result() -> RecipeShoppingInfoResponse:
+    """Create sample shopping result with all data."""
+    return RecipeShoppingInfoResponse(
+        recipe_id=123,
+        ingredients={
+            "flour": IngredientShoppingInfoResponse(
+                ingredient_name="flour",
+                quantity=Quantity(amount=250.0, measurement=IngredientUnit.G),
+                estimated_price="0.45",
+                price_confidence=0.85,
+                data_source="USDA_FVP",
+                currency="USD",
+            ),
+            "sugar": IngredientShoppingInfoResponse(
+                ingredient_name="sugar",
+                quantity=Quantity(amount=100.0, measurement=IngredientUnit.G),
+                estimated_price="0.25",
+                price_confidence=0.90,
+                data_source="USDA_FVP",
+                currency="USD",
+            ),
+        },
+        total_estimated_cost="0.70",
+        missing_ingredients=None,
+    )
+
+
+@pytest.fixture
+def sample_partial_shopping_result() -> RecipeShoppingInfoResponse:
+    """Create sample shopping result with missing ingredients."""
+    return RecipeShoppingInfoResponse(
+        recipe_id=123,
+        ingredients={
+            "flour": IngredientShoppingInfoResponse(
+                ingredient_name="flour",
+                quantity=Quantity(amount=250.0, measurement=IngredientUnit.G),
+                estimated_price="0.45",
+                price_confidence=0.85,
+                data_source="USDA_FVP",
+                currency="USD",
+            ),
+        },
+        total_estimated_cost="0.45",
+        missing_ingredients=[102],
+    )
+
+
+@pytest.fixture
+def mock_recipe_client(sample_recipe_response: RecipeDetailResponse) -> MagicMock:
+    """Create mock recipe client."""
+    mock = MagicMock()
+    mock.get_recipe = AsyncMock(return_value=sample_recipe_response)
+    mock.initialize = AsyncMock()
+    mock.shutdown = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def mock_shopping_service(
+    sample_shopping_result: RecipeShoppingInfoResponse,
+) -> MagicMock:
+    """Create mock shopping service."""
+    mock = MagicMock()
+    mock.get_recipe_shopping_info = AsyncMock(return_value=sample_shopping_result)
+    mock.initialize = AsyncMock()
+    mock.shutdown = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+async def recipe_shopping_client(
+    app: FastAPI,
+    mock_recipe_client: MagicMock,
+    mock_shopping_service: MagicMock,
+) -> AsyncGenerator[AsyncClient]:
+    """Create client with recipe and shopping services mocked."""
+
+    async def mock_get_current_user() -> CurrentUser:
+        return MOCK_USER
+
+    async def mock_get_recipe_client() -> MagicMock:
+        return mock_recipe_client
+
+    async def mock_get_shopping() -> MagicMock:
+        return mock_shopping_service
+
+    # Set dependency overrides
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+    app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+    finally:
+        # Clean up dependency overrides
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_recipe_management_client, None)
+        app.dependency_overrides.pop(get_shopping_service, None)
+
+
+class TestGetRecipeShoppingInfoEndpoint:
+    """Integration tests for GET /recipes/{id}/shopping-info endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_shopping_info_success(
+        self,
+        recipe_shopping_client: AsyncClient,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 200 with shopping data."""
+        response = await recipe_shopping_client.get(
+            "/api/v1/recipe-scraper/recipes/123/shopping-info"
+        )
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "recipeId" in data
+        assert data["recipeId"] == 123
+        assert "ingredients" in data
+        assert "totalEstimatedCost" in data
+        assert data["totalEstimatedCost"] == "0.70"
+
+        # Verify services were called
+        mock_recipe_client.get_recipe.assert_called_once()
+        mock_shopping_service.get_recipe_shopping_info.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_206_with_partial_content_header(
+        self,
+        app: FastAPI,
+        mock_recipe_client: MagicMock,
+        sample_partial_shopping_result: RecipeShoppingInfoResponse,
+    ) -> None:
+        """Should return 206 with X-Partial-Content header when ingredients missing."""
+        mock_partial_shopping = MagicMock()
+        mock_partial_shopping.get_recipe_shopping_info = AsyncMock(
+            return_value=sample_partial_shopping_result
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_recipe_client() -> MagicMock:
+            return mock_recipe_client
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_partial_shopping
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/recipes/123/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_recipe_management_client, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 206
+        assert "x-partial-content" in response.headers
+        assert response.headers["x-partial-content"] == "102"
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_recipe(
+        self,
+        app: FastAPI,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 404 when recipe not found."""
+        mock_client = MagicMock()
+        mock_client.get_recipe = AsyncMock(
+            side_effect=RecipeManagementNotFoundError("Recipe not found")
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_recipe_client() -> MagicMock:
+            return mock_client
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_shopping_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/recipes/999/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_recipe_management_client, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 404
+
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "NOT_FOUND" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_returns_503_for_service_unavailable(
+        self,
+        app: FastAPI,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 503 when Recipe Management Service unavailable."""
+        mock_client = MagicMock()
+        mock_client.get_recipe = AsyncMock(
+            side_effect=RecipeManagementUnavailableError("Service unavailable")
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_recipe_client() -> MagicMock:
+            return mock_client
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_shopping_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/recipes/123/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_recipe_management_client, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 503
+
+        data = response.json()
+        assert data["error"] == "HTTP_ERROR"
+        assert "SERVICE_UNAVAILABLE" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_recipe(
+        self,
+        app: FastAPI,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should handle recipe with no ingredients."""
+        empty_recipe = RecipeDetailResponse(
+            id=123,
+            title="Empty Recipe",
+            ingredients=[],
+        )
+        mock_client = MagicMock()
+        mock_client.get_recipe = AsyncMock(return_value=empty_recipe)
+
+        # Mock returns empty shopping result for empty recipe
+        empty_shopping = RecipeShoppingInfoResponse(
+            recipe_id=123,
+            ingredients={},
+            total_estimated_cost="0.00",
+            missing_ingredients=None,
+        )
+        mock_empty_shopping = MagicMock()
+        mock_empty_shopping.get_recipe_shopping_info = AsyncMock(
+            return_value=empty_shopping
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return MOCK_USER
+
+        async def mock_get_recipe_client() -> MagicMock:
+            return mock_client
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_empty_shopping
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/recipes/123/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_recipe_management_client, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["ingredients"] == {}
+        assert data["totalEstimatedCost"] == "0.00"
+
+    @pytest.mark.asyncio
+    async def test_includes_middleware_headers(
+        self,
+        recipe_shopping_client: AsyncClient,
+    ) -> None:
+        """Should include middleware headers in response."""
+        response = await recipe_shopping_client.get(
+            "/api/v1/recipe-scraper/recipes/123/shopping-info"
+        )
+
+        assert response.status_code == 200
+        assert "x-request-id" in response.headers
+        assert "x-process-time" in response.headers
+
+
+class TestRecipeShoppingInfoAuthentication:
+    """Tests for authentication on recipe shopping info endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_401_without_auth(
+        self,
+        app: FastAPI,
+    ) -> None:
+        """Should return 401 when not authenticated."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/v1/recipe-scraper/recipes/123/shopping-info"
+            )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_returns_403_without_permission(
+        self,
+        app: FastAPI,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Should return 403 when user lacks required permission."""
+        user_without_permission = CurrentUser(
+            id="test-user-no-perms",
+            roles=[],
+            permissions=[],
+        )
+
+        async def mock_get_current_user() -> CurrentUser:
+            return user_without_permission
+
+        async def mock_get_recipe_client() -> MagicMock:
+            return mock_recipe_client
+
+        async def mock_get_shopping() -> MagicMock:
+            return mock_shopping_service
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        app.dependency_overrides[get_recipe_management_client] = mock_get_recipe_client
+        app.dependency_overrides[get_shopping_service] = mock_get_shopping
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/v1/recipe-scraper/recipes/123/shopping-info"
+                )
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(get_recipe_management_client, None)
+            app.dependency_overrides.pop(get_shopping_service, None)
+
+        assert response.status_code == 403

--- a/tests/unit/api/test_recipe_shopping_info.py
+++ b/tests/unit/api/test_recipe_shopping_info.py
@@ -1,0 +1,259 @@
+"""Unit tests for recipe shopping info endpoint.
+
+Tests cover:
+- Get recipe shopping info endpoint
+- Error handling for various failure scenarios
+- 206 Partial Content for missing ingredient prices
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.recipes import get_recipe_shopping_info
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.schemas.shopping import (
+    IngredientShoppingInfoResponse,
+    RecipeShoppingInfoResponse,
+)
+from app.services.recipe_management.exceptions import (
+    RecipeManagementNotFoundError,
+    RecipeManagementUnavailableError,
+)
+from app.services.recipe_management.schemas import (
+    IngredientUnit as RecipeIngredientUnit,
+)
+from app.services.recipe_management.schemas import (
+    RecipeDetailResponse,
+    RecipeIngredientResponse,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetRecipeShoppingInfo:
+    """Tests for get_recipe_shopping_info endpoint."""
+
+    @pytest.fixture
+    def mock_user(self) -> MagicMock:
+        """Create a mock authenticated user."""
+        user = MagicMock()
+        user.id = "user-123"
+        return user
+
+    @pytest.fixture
+    def mock_request(self) -> MagicMock:
+        """Create a mock HTTP request with auth header."""
+        request = MagicMock()
+        request.headers.get.return_value = "Bearer test-token-123"
+        return request
+
+    @pytest.fixture
+    def mock_recipe_client(self) -> MagicMock:
+        """Create a mock recipe management client."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_shopping_service(self) -> MagicMock:
+        """Create a mock shopping service."""
+        return MagicMock()
+
+    @pytest.fixture
+    def sample_recipe_response(self) -> RecipeDetailResponse:
+        """Create sample recipe response with ingredients."""
+        return RecipeDetailResponse(
+            id=123,
+            title="Test Recipe",
+            slug="test-recipe",
+            description="A test recipe",
+            servings=4.0,
+            ingredients=[
+                RecipeIngredientResponse(
+                    id=1,
+                    ingredient_id=101,
+                    ingredient_name="flour",
+                    quantity=250.0,
+                    unit=RecipeIngredientUnit.G,
+                ),
+                RecipeIngredientResponse(
+                    id=2,
+                    ingredient_id=102,
+                    ingredient_name="sugar",
+                    quantity=100.0,
+                    unit=RecipeIngredientUnit.G,
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def sample_shopping_result(self) -> RecipeShoppingInfoResponse:
+        """Create sample shopping result with all data."""
+        return RecipeShoppingInfoResponse(
+            recipe_id=123,
+            ingredients={
+                "flour": IngredientShoppingInfoResponse(
+                    ingredient_name="flour",
+                    quantity=Quantity(amount=250.0, measurement=IngredientUnit.G),
+                    estimated_price="0.62",
+                    price_confidence=0.95,
+                    data_source="USDA_FVP",
+                    currency="USD",
+                ),
+                "sugar": IngredientShoppingInfoResponse(
+                    ingredient_name="sugar",
+                    quantity=Quantity(amount=100.0, measurement=IngredientUnit.G),
+                    estimated_price="0.15",
+                    price_confidence=0.95,
+                    data_source="USDA_FVP",
+                    currency="USD",
+                ),
+            },
+            total_estimated_cost="0.77",
+            missing_ingredients=None,
+        )
+
+    async def test_returns_200_with_complete_shopping_info(
+        self,
+        mock_user: MagicMock,
+        mock_request: MagicMock,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+        sample_recipe_response: RecipeDetailResponse,
+        sample_shopping_result: RecipeShoppingInfoResponse,
+    ) -> None:
+        """Test returns 200 when all ingredients have pricing."""
+        mock_recipe_client.get_recipe = AsyncMock(return_value=sample_recipe_response)
+        mock_shopping_service.get_recipe_shopping_info = AsyncMock(
+            return_value=sample_shopping_result
+        )
+
+        response = await get_recipe_shopping_info(
+            recipe_id=123,
+            user=mock_user,
+            recipe_client=mock_recipe_client,
+            shopping_service=mock_shopping_service,
+            request=mock_request,
+        )
+
+        assert response.status_code == 200
+        mock_recipe_client.get_recipe.assert_called_once_with(123, "test-token-123")
+
+    async def test_returns_206_with_partial_content(
+        self,
+        mock_user: MagicMock,
+        mock_request: MagicMock,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+        sample_recipe_response: RecipeDetailResponse,
+    ) -> None:
+        """Test returns 206 when some ingredients missing prices."""
+        partial_result = RecipeShoppingInfoResponse(
+            recipe_id=123,
+            ingredients={
+                "flour": IngredientShoppingInfoResponse(
+                    ingredient_name="flour",
+                    quantity=Quantity(amount=250.0, measurement=IngredientUnit.G),
+                    estimated_price="0.62",
+                    price_confidence=0.95,
+                    data_source="USDA_FVP",
+                    currency="USD",
+                ),
+            },
+            total_estimated_cost="0.62",
+            missing_ingredients=[102],
+        )
+        mock_recipe_client.get_recipe = AsyncMock(return_value=sample_recipe_response)
+        mock_shopping_service.get_recipe_shopping_info = AsyncMock(
+            return_value=partial_result
+        )
+
+        response = await get_recipe_shopping_info(
+            recipe_id=123,
+            user=mock_user,
+            recipe_client=mock_recipe_client,
+            shopping_service=mock_shopping_service,
+            request=mock_request,
+        )
+
+        assert response.status_code == 206
+        assert response.headers["X-Partial-Content"] == "102"
+
+    async def test_returns_404_when_recipe_not_found(
+        self,
+        mock_user: MagicMock,
+        mock_request: MagicMock,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Test returns 404 when recipe doesn't exist."""
+        mock_recipe_client.get_recipe = AsyncMock(
+            side_effect=RecipeManagementNotFoundError("Recipe not found")
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_recipe_shopping_info(
+                recipe_id=999,
+                user=mock_user,
+                recipe_client=mock_recipe_client,
+                shopping_service=mock_shopping_service,
+                request=mock_request,
+            )
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in str(exc_info.value.detail)
+
+    async def test_returns_503_when_service_unavailable(
+        self,
+        mock_user: MagicMock,
+        mock_request: MagicMock,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Test returns 503 when Recipe Management Service unavailable."""
+        mock_recipe_client.get_recipe = AsyncMock(
+            side_effect=RecipeManagementUnavailableError("Service unavailable")
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_recipe_shopping_info(
+                recipe_id=123,
+                user=mock_user,
+                recipe_client=mock_recipe_client,
+                shopping_service=mock_shopping_service,
+                request=mock_request,
+            )
+
+        assert exc_info.value.status_code == 503
+
+    async def test_handles_empty_recipe(
+        self,
+        mock_user: MagicMock,
+        mock_request: MagicMock,
+        mock_recipe_client: MagicMock,
+        mock_shopping_service: MagicMock,
+    ) -> None:
+        """Test handles recipe with no ingredients."""
+        empty_recipe = RecipeDetailResponse(
+            id=123,
+            title="Empty Recipe",
+            slug="empty-recipe",
+            ingredients=[],
+        )
+        mock_recipe_client.get_recipe = AsyncMock(return_value=empty_recipe)
+
+        response = await get_recipe_shopping_info(
+            recipe_id=123,
+            user=mock_user,
+            recipe_client=mock_recipe_client,
+            shopping_service=mock_shopping_service,
+            request=mock_request,
+        )
+
+        assert response.status_code == 200
+        # Shopping service should not be called for empty recipe
+        mock_shopping_service.get_recipe_shopping_info.assert_not_called()

--- a/tests/unit/database/test_shopping_repository.py
+++ b/tests/unit/database/test_shopping_repository.py
@@ -1,0 +1,306 @@
+"""Unit tests for PricingRepository.
+
+Tests cover:
+- Getting pricing data by ingredient ID (Tier 1)
+- Getting pricing data by food group (Tier 2 fallback)
+- Getting ingredient details
+- Handling missing data and tables
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.database.repositories.shopping import (
+    IngredientDetails,
+    PricingData,
+    PricingRepository,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    """Create a mock asyncpg pool."""
+    pool = MagicMock()
+    pool.close = AsyncMock()
+
+    # Mock connection context manager
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=None)
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    pool.acquire = MagicMock(return_value=AsyncMock())
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    return pool
+
+
+@pytest.fixture
+def repository(mock_pool: MagicMock) -> PricingRepository:
+    """Create repository with mock pool."""
+    return PricingRepository(pool=mock_pool)
+
+
+@pytest.fixture
+def sample_tier1_pricing_row() -> dict:
+    """Create a sample Tier 1 pricing database row."""
+    return {
+        "price_per_100g": Decimal("0.5250"),
+        "currency": "USD",
+        "data_source": "USDA_FVP",
+        "source_year": 2024,
+    }
+
+
+@pytest.fixture
+def sample_tier2_pricing_row() -> dict:
+    """Create a sample Tier 2 (food group) pricing database row."""
+    return {
+        "price_per_100g": Decimal("0.4500"),
+        "currency": "USD",
+        "data_source": "USDA_FMAP",
+    }
+
+
+@pytest.fixture
+def sample_ingredient_details_row() -> dict:
+    """Create a sample ingredient details database row."""
+    return {
+        "ingredient_id": 123,
+        "name": "chicken breast",
+        "food_group": "POULTRY",
+    }
+
+
+class TestPricingDataModel:
+    """Tests for PricingData Pydantic model."""
+
+    def test_tier1_pricing_data(self) -> None:
+        """Test creating Tier 1 pricing data."""
+        data = PricingData(
+            price_per_100g=Decimal("0.5250"),
+            currency="USD",
+            data_source="USDA_FVP",
+            source_year=2024,
+            tier=1,
+        )
+        assert data.price_per_100g == Decimal("0.5250")
+        assert data.currency == "USD"
+        assert data.data_source == "USDA_FVP"
+        assert data.source_year == 2024
+        assert data.tier == 1
+
+    def test_tier2_pricing_data(self) -> None:
+        """Test creating Tier 2 pricing data (no source_year)."""
+        data = PricingData(
+            price_per_100g=Decimal("0.4500"),
+            currency="USD",
+            data_source="USDA_FMAP",
+            tier=2,
+        )
+        assert data.price_per_100g == Decimal("0.4500")
+        assert data.source_year is None
+        assert data.tier == 2
+
+
+class TestIngredientDetailsModel:
+    """Tests for IngredientDetails Pydantic model."""
+
+    def test_ingredient_details_with_food_group(self) -> None:
+        """Test creating ingredient details with food group."""
+        details = IngredientDetails(
+            ingredient_id=123,
+            name="chicken breast",
+            food_group="POULTRY",
+        )
+        assert details.ingredient_id == 123
+        assert details.name == "chicken breast"
+        assert details.food_group == "POULTRY"
+
+    def test_ingredient_details_without_food_group(self) -> None:
+        """Test creating ingredient details without food group."""
+        details = IngredientDetails(
+            ingredient_id=456,
+            name="mystery ingredient",
+        )
+        assert details.ingredient_id == 456
+        assert details.name == "mystery ingredient"
+        assert details.food_group is None
+
+
+class TestGetPriceByIngredientId:
+    """Tests for Tier 1 pricing lookup."""
+
+    async def test_returns_pricing_data_when_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+        sample_tier1_pricing_row: dict,
+    ) -> None:
+        """Test successful Tier 1 pricing lookup."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = sample_tier1_pricing_row
+
+        result = await repository.get_price_by_ingredient_id(123)
+
+        assert result is not None
+        assert result.price_per_100g == Decimal("0.5250")
+        assert result.currency == "USD"
+        assert result.data_source == "USDA_FVP"
+        assert result.source_year == 2024
+        assert result.tier == 1
+
+    async def test_returns_none_when_not_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test Tier 1 lookup returns None when ingredient not in pricing table."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = None
+
+        result = await repository.get_price_by_ingredient_id(999)
+
+        assert result is None
+
+    async def test_handles_missing_table_gracefully(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test graceful handling when ingredient_pricing table doesn't exist."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.side_effect = Exception(
+            'relation "recipe_manager.ingredient_pricing" does not exist'
+        )
+
+        result = await repository.get_price_by_ingredient_id(123)
+
+        assert result is None
+
+
+class TestGetPriceByFoodGroup:
+    """Tests for Tier 2 pricing lookup."""
+
+    async def test_returns_pricing_data_when_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+        sample_tier2_pricing_row: dict,
+    ) -> None:
+        """Test successful Tier 2 pricing lookup."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = sample_tier2_pricing_row
+
+        result = await repository.get_price_by_food_group("VEGETABLES")
+
+        assert result is not None
+        assert result.price_per_100g == Decimal("0.4500")
+        assert result.currency == "USD"
+        assert result.data_source == "USDA_FMAP"
+        assert result.source_year is None
+        assert result.tier == 2
+
+    async def test_returns_none_when_food_group_not_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test Tier 2 lookup returns None when food group not in pricing table."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = None
+
+        result = await repository.get_price_by_food_group("UNKNOWN")
+
+        assert result is None
+
+    async def test_handles_invalid_enum_gracefully(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test graceful handling when food group is not a valid enum value."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.side_effect = Exception(
+            'invalid input value for enum recipe_manager.food_group_enum: "INVALID"'
+        )
+
+        result = await repository.get_price_by_food_group("INVALID")
+
+        assert result is None
+
+    async def test_handles_missing_table_gracefully(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test graceful handling when food_group_pricing table doesn't exist."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.side_effect = Exception(
+            'relation "recipe_manager.food_group_pricing" does not exist'
+        )
+
+        result = await repository.get_price_by_food_group("VEGETABLES")
+
+        assert result is None
+
+
+class TestGetIngredientDetails:
+    """Tests for ingredient details lookup."""
+
+    async def test_returns_details_when_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+        sample_ingredient_details_row: dict,
+    ) -> None:
+        """Test successful ingredient details lookup."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = sample_ingredient_details_row
+
+        result = await repository.get_ingredient_details(123)
+
+        assert result is not None
+        assert result.ingredient_id == 123
+        assert result.name == "chicken breast"
+        assert result.food_group == "POULTRY"
+
+    async def test_returns_none_when_not_found(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test returns None when ingredient doesn't exist."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = None
+
+        result = await repository.get_ingredient_details(999)
+
+        assert result is None
+
+    async def test_returns_details_without_food_group(
+        self,
+        repository: PricingRepository,
+        mock_pool: MagicMock,
+    ) -> None:
+        """Test returns details when ingredient has no nutrition profile."""
+        mock_conn = mock_pool.acquire.return_value.__aenter__.return_value
+        mock_conn.fetchrow.return_value = {
+            "ingredient_id": 456,
+            "name": "mystery ingredient",
+            "food_group": None,
+        }
+
+        result = await repository.get_ingredient_details(456)
+
+        assert result is not None
+        assert result.ingredient_id == 456
+        assert result.name == "mystery ingredient"
+        assert result.food_group is None

--- a/tests/unit/services/shopping/__init__.py
+++ b/tests/unit/services/shopping/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for shopping service."""

--- a/tests/unit/services/shopping/test_service.py
+++ b/tests/unit/services/shopping/test_service.py
@@ -1,0 +1,343 @@
+"""Unit tests for ShoppingService.
+
+Tests cover:
+- Getting ingredient shopping info
+- Two-tier pricing lookup (Tier 1 → Tier 2 fallback)
+- Price calculation based on quantity
+- Cache behavior
+- Error handling
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import orjson
+import pytest
+
+from app.database.repositories.shopping import IngredientDetails, PricingData
+from app.schemas.enums import IngredientUnit
+from app.schemas.ingredient import Quantity
+from app.services.shopping.constants import TIER_1_CONFIDENCE, TIER_2_CONFIDENCE
+from app.services.shopping.exceptions import IngredientNotFoundError
+from app.services.shopping.service import ShoppingService
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_cache_client() -> AsyncMock:
+    """Create a mock Redis cache client."""
+    client = AsyncMock()
+    client.get.return_value = None
+    client.setex.return_value = True
+    return client
+
+
+@pytest.fixture
+def mock_repository() -> AsyncMock:
+    """Create a mock PricingRepository."""
+    repo = AsyncMock()
+    repo.get_ingredient_details.return_value = None
+    repo.get_price_by_ingredient_id.return_value = None
+    repo.get_price_by_food_group.return_value = None
+    return repo
+
+
+@pytest.fixture
+def mock_nutrition_repository() -> AsyncMock:
+    """Create a mock NutritionRepository."""
+    repo = AsyncMock()
+    repo.get_portion_weight.return_value = None
+    return repo
+
+
+@pytest.fixture
+def service(
+    mock_cache_client: AsyncMock,
+    mock_repository: AsyncMock,
+    mock_nutrition_repository: AsyncMock,
+) -> ShoppingService:
+    """Create ShoppingService with mocked dependencies."""
+    svc = ShoppingService(
+        cache_client=mock_cache_client,
+        repository=mock_repository,
+        nutrition_repository=mock_nutrition_repository,
+    )
+    # Manually set initialized flag and converter
+    svc._initialized = True
+    svc._converter = MagicMock()
+    svc._converter.to_grams = AsyncMock(return_value=Decimal(100))
+    return svc
+
+
+@pytest.fixture
+def sample_ingredient_details() -> IngredientDetails:
+    """Create sample ingredient details."""
+    return IngredientDetails(
+        ingredient_id=123,
+        name="chicken breast",
+        food_group="POULTRY",
+    )
+
+
+@pytest.fixture
+def sample_tier1_pricing() -> PricingData:
+    """Create sample Tier 1 pricing data."""
+    return PricingData(
+        price_per_100g=Decimal("0.5250"),
+        currency="USD",
+        data_source="USDA_MEAT",
+        source_year=2024,
+        tier=1,
+    )
+
+
+@pytest.fixture
+def sample_tier2_pricing() -> PricingData:
+    """Create sample Tier 2 pricing data."""
+    return PricingData(
+        price_per_100g=Decimal("0.4500"),
+        currency="USD",
+        data_source="USDA_FMAP",
+        tier=2,
+    )
+
+
+class TestGetIngredientShoppingInfo:
+    """Tests for get_ingredient_shopping_info method."""
+
+    async def test_returns_tier1_pricing(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+        sample_tier1_pricing: PricingData,
+    ) -> None:
+        """Test returns Tier 1 pricing when available."""
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = sample_tier1_pricing
+
+        result = await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        assert result.ingredient_name == "chicken breast"
+        assert result.estimated_price == "0.52"  # 100g * 0.5250/100g
+        assert result.price_confidence == float(TIER_1_CONFIDENCE)
+        assert result.data_source == "USDA_MEAT"
+        assert result.currency == "USD"
+
+    async def test_falls_back_to_tier2_pricing(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+        sample_tier2_pricing: PricingData,
+    ) -> None:
+        """Test falls back to Tier 2 when Tier 1 not available."""
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = None
+        mock_repository.get_price_by_food_group.return_value = sample_tier2_pricing
+
+        result = await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        assert result.ingredient_name == "chicken breast"
+        assert result.estimated_price == "0.45"  # 100g * 0.4500/100g
+        assert result.price_confidence == float(TIER_2_CONFIDENCE)
+        assert result.data_source == "USDA_FMAP"
+        mock_repository.get_price_by_food_group.assert_called_once_with("POULTRY")
+
+    async def test_returns_null_price_when_no_pricing_data(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+    ) -> None:
+        """Test returns null price when neither Tier 1 nor Tier 2 available."""
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = None
+        mock_repository.get_price_by_food_group.return_value = None
+
+        result = await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        assert result.ingredient_name == "chicken breast"
+        assert result.estimated_price is None
+        assert result.price_confidence is None
+        assert result.data_source is None
+
+    async def test_raises_error_when_ingredient_not_found(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Test raises IngredientNotFoundError when ingredient doesn't exist."""
+        mock_repository.get_ingredient_details.return_value = None
+
+        with pytest.raises(IngredientNotFoundError) as exc_info:
+            await service.get_ingredient_shopping_info(ingredient_id=999)
+
+        assert "Ingredient not found: 999" in str(exc_info.value)
+        assert exc_info.value.ingredient_id == 999
+
+    async def test_calculates_price_for_quantity(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+        sample_tier1_pricing: PricingData,
+    ) -> None:
+        """Test calculates price based on provided quantity."""
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = sample_tier1_pricing
+        # Mock conversion: 2 cups = 500g
+        service._converter.to_grams.return_value = Decimal(500)
+
+        quantity = Quantity(amount=2.0, measurement=IngredientUnit.CUP)
+        result = await service.get_ingredient_shopping_info(
+            ingredient_id=123,
+            quantity=quantity,
+        )
+
+        # 500g * 0.5250/100g = 2.625
+        assert result.estimated_price == "2.62"
+        assert result.quantity.amount == 2.0
+        assert result.quantity.measurement == IngredientUnit.CUP
+
+    async def test_defaults_to_100g_when_no_quantity(
+        self,
+        service: ShoppingService,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+        sample_tier1_pricing: PricingData,
+    ) -> None:
+        """Test defaults to 100g when no quantity provided."""
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = sample_tier1_pricing
+
+        result = await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        assert result.quantity.amount == 100.0
+        assert result.quantity.measurement == IngredientUnit.G
+
+
+class TestCaching:
+    """Tests for caching behavior."""
+
+    async def test_returns_cached_result(
+        self,
+        service: ShoppingService,
+        mock_cache_client: AsyncMock,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Test returns cached result without hitting repository."""
+        cached_response = {
+            "ingredientName": "chicken breast",
+            "quantity": {"amount": 100.0, "measurement": "G"},
+            "estimatedPrice": "0.52",
+            "priceConfidence": 0.95,
+            "dataSource": "USDA_MEAT",
+            "currency": "USD",
+        }
+        mock_cache_client.get.return_value = orjson.dumps(cached_response)
+
+        result = await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        assert result.ingredient_name == "chicken breast"
+        assert result.estimated_price == "0.52"
+        mock_repository.get_ingredient_details.assert_not_called()
+
+    async def test_caches_result_after_fetch(
+        self,
+        service: ShoppingService,
+        mock_cache_client: AsyncMock,
+        mock_repository: AsyncMock,
+        sample_ingredient_details: IngredientDetails,
+        sample_tier1_pricing: PricingData,
+    ) -> None:
+        """Test caches result after fetching from repository."""
+        mock_cache_client.get.return_value = None
+        mock_repository.get_ingredient_details.return_value = sample_ingredient_details
+        mock_repository.get_price_by_ingredient_id.return_value = sample_tier1_pricing
+
+        await service.get_ingredient_shopping_info(ingredient_id=123)
+
+        mock_cache_client.setex.assert_called_once()
+        call_args = mock_cache_client.setex.call_args
+        assert "shopping:123:100.0:G" in call_args[0][0]
+
+
+class TestPriceCalculation:
+    """Tests for price calculation logic."""
+
+    def test_calculate_price_100g(self, service: ShoppingService) -> None:
+        """Test price calculation for 100g."""
+        price = service._calculate_price(
+            price_per_100g=Decimal("0.5250"),
+            grams=Decimal(100),
+        )
+        assert price == Decimal("0.5250")
+
+    def test_calculate_price_500g(self, service: ShoppingService) -> None:
+        """Test price calculation for 500g."""
+        price = service._calculate_price(
+            price_per_100g=Decimal("0.5250"),
+            grams=Decimal(500),
+        )
+        assert price == Decimal("2.625")
+
+    def test_calculate_price_50g(self, service: ShoppingService) -> None:
+        """Test price calculation for 50g."""
+        price = service._calculate_price(
+            price_per_100g=Decimal("0.5250"),
+            grams=Decimal(50),
+        )
+        assert price == Decimal("0.2625")
+
+
+class TestCacheKey:
+    """Tests for cache key generation."""
+
+    def test_cache_key_format(self, service: ShoppingService) -> None:
+        """Test cache key format."""
+        quantity = Quantity(amount=2.5, measurement=IngredientUnit.CUP)
+        key = service._make_cache_key(123, quantity)
+        assert key == "shopping:123:2.5:CUP"
+
+    def test_cache_key_with_grams(self, service: ShoppingService) -> None:
+        """Test cache key with gram quantity."""
+        quantity = Quantity(amount=100.0, measurement=IngredientUnit.G)
+        key = service._make_cache_key(456, quantity)
+        assert key == "shopping:456:100.0:G"
+
+
+class TestServiceLifecycle:
+    """Tests for service initialization and shutdown."""
+
+    async def test_initialize_sets_initialized_flag(self) -> None:
+        """Test initialize sets the initialized flag."""
+        service = ShoppingService()
+
+        with patch("app.services.shopping.service.get_cache_client") as mock_cache:
+            mock_cache.return_value = AsyncMock()
+            await service.initialize()
+
+        assert service._initialized is True
+
+    async def test_shutdown_clears_initialized_flag(
+        self,
+        service: ShoppingService,
+    ) -> None:
+        """Test shutdown clears the initialized flag."""
+        assert service._initialized is True
+
+        await service.shutdown()
+
+        assert service._initialized is False
+
+    async def test_raises_error_when_not_initialized(self) -> None:
+        """Test raises error when service not initialized."""
+        service = ShoppingService()
+
+        with pytest.raises(RuntimeError, match="ShoppingService not initialized"):
+            await service.get_ingredient_shopping_info(ingredient_id=123)


### PR DESCRIPTION
## Summary
- Implement ingredient shopping info endpoint (`GET /ingredients/{id}/shopping-info`)
- Implement recipe shopping info endpoint (`GET /recipes/{id}/shopping-info`)
- Add comprehensive test coverage for both endpoints

## Features
- Two-tier pricing lookup (direct ingredient → food group fallback)
- Support for quantity parameters with unit conversion
- 206 Partial Content response when some ingredients missing prices
- Full authentication and authorization

## Test Coverage
| Endpoint | Integration | E2E | Performance |
|----------|-------------|-----|-------------|
| `/ingredients/{id}/shopping-info` | 9 tests | 5 tests | 3 benchmarks |
| `/recipes/{id}/shopping-info` | 8 tests | 4 tests | 3 benchmarks |

**Total: 32 new tests**

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] All e2e tests pass
- [x] All performance benchmarks pass

🤖 Generated with [Claude Code](https://claude.ai/code)